### PR TITLE
Add GUI for custom STAC catalogs

### DIFF
--- a/docs/notebooks/73_custom_stac.ipynb
+++ b/docs/notebooks/73_custom_stac.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=notebooks/73_custom_stac.ipynb)\n",
+    "[![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/73_custom_stac.ipynb)\n",
+    "[![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/73_custom_stac.ipynb&branch=master)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://githubtocolab.com/opengeos/leafmap/blob/master/examples/notebooks/73_custom_stac.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://gishub.org/leafmap-binder)\n",
+    "\n",
+    "**Searching Geospatial Data Interactively with Custom STAC API Endpoints**\n",
+    "\n",
+    "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U leafmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import leafmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Provide custom STAC API endpoints as a dictionary in the format of `{\"name\": \"url\"}`. The name will show up in the dropdown menu, while the url is the STAC API endpoint that will be used to search for items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalogs = {\n",
+    "    \"Element84 Earth Search\": \"https://earth-search.aws.element84.com/v1\",\n",
+    "    \"Microsoft Planetary Computer\": \"https://planetarycomputer.microsoft.com/api/stac/v1\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an interactive map and click on the catalog button as shown below to open the catalog panel. Be sure to specify the `catalog_source` parameter during the map creation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/IrnRrcF.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[40, -100], zoom=4, catalog_source=catalogs)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, you can also use the `Map.set_catalog_source` method to specify the custom API endpoints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[40, -100], zoom=4)\n",
+    "m.set_catalog_source(catalogs)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another way to specify STAC API endpoints is to set the environment variable `STAC_CATALOGS` to a dictionary in the format of `{\"name\": \"url\"}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['STAC_CATALOGS'] = str(catalogs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, you can create an interactive map as usual and click on the catalog button to open the catalog panel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The STAC GUI can also be open directly by calling the `stac_gui()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from leafmap.toolbar import stac_gui"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stac_gui(m)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the catalog panel is open, you can search for items from the custom STAC API endpoints. Simply draw a bounding box on the map or zoom to a location of interest. Click on the **Collections** button to retrieve the collections from the custom STAC API endpoints. Next, select a collection from the dropdown menu. Then, click on the **Items** button to retrieve the items from the selected collection. Finally, click on the **Display** button to add the selected item to the map."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/iv0f6aK.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m.stac_gdf  # The GeoDataFrame of the STAC search results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m.stac_dict  # The STAC search results as a dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m.stac_item  # The selected STAC item of the search result"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/73_custom_stac.ipynb
+++ b/docs/notebooks/73_custom_stac.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import leafmap"
+    "from leafmap import leafmap"
    ]
   },
   {

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -86,6 +86,7 @@
 70. Calculating zonal statistics - summarizing geospatial raster datasets based on vector geometries ([notebook](https://leafmap.org/notebooks/70_zonal_stats))
 71. Loading geospatial datasets from an AWS S3 bucket ([notebook](https://leafmap.org/notebooks/71_aws_s3))
 72. Creating timelapse animations from satellite imagery timeseries ([notebook](https://leafmap.org/notebooks/72_timelapse))
+73. Searching Geospatial Data Interactively with Custom STAC API Endpoints ([notebook](https://leafmap.org/notebooks/73_custom_stac))
 
 ## Demo
 

--- a/docs/workshops/YouthMappers_2021.ipynb
+++ b/docs/workshops/YouthMappers_2021.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "This notebook was developed for the 90-min [leafmap workshop](https://www.eventbrite.com/e/interactive-mapping-and-geospatial-analysis-tickets-188600217327?keep_tld=1) taking place on November 9, 2021. The workshop is hosted by [YouthMappers](https://www.youthmappers.org).\n",
     "\n",
-    "- Author: [Qiusheng Wu](https://github.com/giswqs)\n",
+    "- Author: [Qiusheng Wu](https://github.com/opengeos)\n",
     "- Slides: https://gishub.org/ym \n",
     "- Streamlit web app: https://streamlit.gishub.org\n",
     "\n",

--- a/examples/README.md
+++ b/examples/README.md
@@ -93,6 +93,7 @@
 70. Calculating zonal statistics - summarizing geospatial raster datasets based on vector geometries ([notebook](https://leafmap.org/notebooks/70_zonal_stats))
 71. Loading geospatial datasets from an AWS S3 bucket ([notebook](https://leafmap.org/notebooks/71_aws_s3))
 72. Creating timelapse animations from satellite imagery timeseries ([notebook](https://leafmap.org/notebooks/72_timelapse))
+73. Searching Geospatial Data Interactively with Custom STAC API Endpoints ([notebook](https://leafmap.org/notebooks/73_custom_stac))
 
 ## Demo
 

--- a/examples/notebooks/73_custom_stac.ipynb
+++ b/examples/notebooks/73_custom_stac.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=notebooks/73_custom_stac.ipynb)\n",
+    "[![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/73_custom_stac.ipynb)\n",
+    "[![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/73_custom_stac.ipynb&branch=master)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://githubtocolab.com/opengeos/leafmap/blob/master/examples/notebooks/73_custom_stac.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://gishub.org/leafmap-binder)\n",
+    "\n",
+    "**Searching Geospatial Data Interactively with Custom STAC API Endpoints**\n",
+    "\n",
+    "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U leafmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import leafmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Provide custom STAC API endpoints as a dictionary in the format of `{\"name\": \"url\"}`. The name will show up in the dropdown menu, while the url is the STAC API endpoint that will be used to search for items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalogs = {\n",
+    "    \"Element84 Earth Search\": \"https://earth-search.aws.element84.com/v1\",\n",
+    "    \"Microsoft Planetary Computer\": \"https://planetarycomputer.microsoft.com/api/stac/v1\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an interactive map and click on the catalog button as shown below to open the catalog panel. Be sure to specify the `catalog_source` parameter during the map creation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/IrnRrcF.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[40, -100], zoom=4, catalog_source=catalogs)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, you can also use the `Map.set_catalog_source` method to specify the custom API endpoints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[40, -100], zoom=4)\n",
+    "m.set_catalog_source(catalogs)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another way to specify STAC API endpoints is to set the environment variable `STAC_CATALOGS` to a dictionary in the format of `{\"name\": \"url\"}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['STAC_CATALOGS'] = str(catalogs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, you can create an interactive map as usual and click on the catalog button to open the catalog panel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The STAC GUI can also be open directly by calling the `stac_gui()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from leafmap.toolbar import stac_gui"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stac_gui(m)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the catalog panel is open, you can search for items from the custom STAC API endpoints. Simply draw a bounding box on the map or zoom to a location of interest. Click on the **Collections** button to retrieve the collections from the custom STAC API endpoints. Next, select a collection from the dropdown menu. Then, click on the **Items** button to retrieve the items from the selected collection. Finally, click on the **Display** button to add the selected item to the map."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/iv0f6aK.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m.stac_gdf  # The GeoDataFrame of the STAC search results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m.stac_dict  # The STAC search results as a dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m.stac_item  # The selected STAC item of the search result"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/73_custom_stac.ipynb
+++ b/examples/notebooks/73_custom_stac.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import leafmap"
+    "from leafmap import leafmap"
    ]
   },
   {

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -7413,17 +7413,17 @@ def create_timelapse(
 
     output = widgets.Output()
 
-    if 'out_ext' in kwargs:
-        out_ext = kwargs['out_ext'].lower()
+    if "out_ext" in kwargs:
+        out_ext = kwargs["out_ext"].lower()
     else:
-        out_ext = '.jpg'
+        out_ext = ".jpg"
 
     try:
         for index, image in enumerate(images):
-            if 'add_prefix' in kwargs:
+            if "add_prefix" in kwargs:
                 basename = (
-                    str(f'{index + 1}').zfill(len(str(len(images))))
-                    + '-'
+                    str(f"{index + 1}").zfill(len(str(len(images))))
+                    + "-"
                     + os.path.basename(image).replace(ext, out_ext)
                 )
             else:
@@ -7436,7 +7436,15 @@ def create_timelapse(
                 numpy_to_image(
                     image, os.path.join(temp_dir, basename), bands=bands, size=size
                 )
-        make_gif(temp_dir, out_gif, ext=out_ext, fps=fps, loop=loop, mp4=mp4, clean_up=clean_up)
+        make_gif(
+            temp_dir,
+            out_gif,
+            ext=out_ext,
+            fps=fps,
+            loop=loop,
+            mp4=mp4,
+            clean_up=clean_up,
+        )
 
         if add_text:
             add_text_to_gif(

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -200,6 +200,9 @@ class Map(ipyleaflet.Map):
         if "use_voila" not in kwargs:
             kwargs["use_voila"] = False
 
+        if "catalog_source" in kwargs:
+            self.set_catalog_source(kwargs["catalog_source"])
+
     def set_center(self, lon, lat, zoom=None):
         """Centers the map view at a given coordinates with the given zoom level.
 
@@ -3846,6 +3849,22 @@ class Map(ipyleaflet.Map):
                     )
         else:
             print("No images found.")
+
+    def set_catalog_source(self, source):
+        """Set the catalog source.
+
+        Args:
+            catalog_source (str, optional): The catalog source. Defaults to "landsat".
+        """
+        if not isinstance(source, dict):
+            raise TypeError(
+                "The source must be a dictionary in the format of {label: url, label2:url2}, \
+                such as {'Element84': 'https://earth-search.aws.element84.com/v1'}"
+            )
+        if not hasattr(self, "_STAC_CATALOGS"):
+            self.catalog_source = {}
+
+        self._STAC_CATALOGS = source
 
 
 # The functions below are outside the Map class.

--- a/leafmap/stac.py
+++ b/leafmap/stac.py
@@ -621,6 +621,38 @@ def stac_tile(
         if assets is not None:
             kwargs["assets"] = assets
 
+        if (
+            (assets is not None)
+            and ("asset_expression" not in kwargs)
+            and ("expression" not in kwargs)
+            and ("rescale" not in kwargs)
+        ):
+            stats = stac_stats(
+                url=url,
+                assets=assets,
+                titiler_endpoint=titiler_endpoint,
+            )
+            if "detail" not in stats:
+                try:
+                    percentile_2 = min([stats[s]["percentile_2"] for s in stats])
+                    percentile_98 = max([stats[s]["percentile_98"] for s in stats])
+                except:
+                    percentile_2 = min(
+                        [
+                            stats[s][list(stats[s].keys())[0]]["percentile_2"]
+                            for s in stats
+                        ]
+                    )
+                    percentile_98 = max(
+                        [
+                            stats[s][list(stats[s].keys())[0]]["percentile_98"]
+                            for s in stats
+                        ]
+                    )
+                kwargs["rescale"] = f"{percentile_2},{percentile_98}"
+            else:
+                print(stats["detail"])  # When operation times out.
+
     TileMatrixSetId = "WebMercatorQuad"
     if "TileMatrixSetId" in kwargs.keys():
         TileMatrixSetId = kwargs["TileMatrixSetId"]
@@ -1363,6 +1395,7 @@ def set_default_bands(bands):
         "tir-browse",
         "vnir-browse",
         "xml",
+        "documentation",
     ]
 
     for band in excluded:

--- a/leafmap/toolbar.py
+++ b/leafmap/toolbar.py
@@ -5127,52 +5127,7 @@ def stac_custom_gui(m=None):
     if "MAX_ITEMS" in os.environ:
         MAX_ITEMS = int(os.environ["MAX_ITEMS"])
 
-    catalog_path = download_data_catalogs()
-    aws_open_data_path = os.path.join(catalog_path, "aws_stac_catalogs.tsv")
-    gee_path = os.path.join(catalog_path, "gee_catalog.tsv")
-    pc_path = os.path.join(catalog_path, "pc_catalog.tsv")
-    nasa_path = os.path.join(catalog_path, "nasa_cmr_catalog.tsv")
-    stac_index_path = os.path.join(catalog_path, "stac_catalogs.tsv")
     stac_data = []
-
-    stac_info = {
-        "AWS Open Data": {
-            "filename": aws_open_data_path,
-            "name": "Name",
-            "url": "Endpoint",
-            "description": "Description",
-        },
-        "Google Earth Engine": {
-            "filename": gee_path,
-            "name": "id",
-            "url": "url",
-            "description": "title",
-        },
-        "Microsoft Planetary Computer": {
-            "filename": pc_path,
-            "name": "title",
-            "url": "link",
-            "description": "description",
-        },
-        "NASA Common Metadata Repository": {
-            "filename": nasa_path,
-            "name": "id",
-            "url": "url",
-            "description": "title",
-        },
-        "STAC Index Catalogs": {
-            "filename": stac_index_path,
-            "name": "title",
-            "url": "url",
-            "description": "summary",
-        },
-        "Custom STAC API Endpoint": {
-            "filename": "",
-            "name": "",
-            "url": "",
-            "description": "",
-        },
-    }
 
     output = widgets.Output(
         layout=widgets.Layout(width=widget_width, padding=padding, overflow="auto")
@@ -5444,10 +5399,7 @@ def stac_custom_gui(m=None):
     )
 
     def update_bands():
-        if len(stac_data) > 0:
-            bnames = stac_data[0][item.value]["bands"]
-        else:
-            bnames = []
+        bnames = []
 
         red.options = bnames
         green.options = bnames

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,9 +51,7 @@ plugins:
           execute: True
           allow_errors: false
           ignore: ["conf.py", "data/README.md", "usage.md"]
-          execute_ignore:
-              ["workshops/*.ipynb", "notebooks/zz_notebook_template.ipynb"]
-          #   execute_ignore: "notebooks/26_kepler_gl.ipynb"
+          execute_ignore: ["workshops/*.ipynb", "notebooks/52_netcdf.ipynb"]
 
 markdown_extensions:
     - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,3 +186,4 @@ nav:
           - notebooks/70_zonal_stats.ipynb
           - notebooks/71_aws_s3.ipynb
           - notebooks/72_timelapse.ipynb
+          - notebooks/73_custom_stac.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,12 @@ plugins:
           execute: True
           allow_errors: false
           ignore: ["conf.py", "data/README.md", "usage.md"]
-          execute_ignore: ["workshops/*.ipynb", "notebooks/52_netcdf.ipynb"]
+          execute_ignore:
+              [
+                  "workshops/*.ipynb",
+                  "notebooks/52_netcdf.ipynb",
+                  "notebooks/57_national_map.ipynb",
+              ]
 
 markdown_extensions:
     - admonition

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -4,7 +4,7 @@ flake8
 grip
 ipykernel
 livereload
-nbconvert==6.5.3
+nbconvert
 nbformat
 pip
 sphinx

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -4,7 +4,7 @@ flake8
 grip
 ipykernel
 livereload
-nbconvert
+nbconvert==6.5.3
 nbformat
 pip
 sphinx


### PR DESCRIPTION
This new feature allows users to specify a list of STAC catalogs through an environment variable, map initialization, or map attribute. 

Working in progress. The following code is just for testing. After the implementation is completed, the GUI should be accessible through the toolbar.  @abarciauskas-bgse

```python
import leafmap
from leafmap.toolbar import stac_custom_gui
catalogs = {
    "MAAP": "https://stac.maap-project.org",
    "Earth Search": "https://earth-search.aws.element84.com/v1",
    "Planetary Computer": "https://planetarycomputer.microsoft.com/api/stac/v1",
}
m = leafmap.Map()
setattr(m, "_STAC_CATALOGS", catalogs)
stac_custom_gui(m)
m
```
<img width="977" alt="image" src="https://user-images.githubusercontent.com/5016453/230703505-80de1170-1f56-44eb-a11e-7e983cd03ed2.png">
