### PR TITLE
Add request_modifier param to stac_client

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -3845,13 +3845,15 @@ def numpy_to_cog(
             )
 
 
-def get_stac_collections(url):
+def get_stac_collections(url, **kwargs):
     """Retrieve a list of STAC collections from a URL.
     This function is adapted from https://github.com/mykolakozyr/stacdiscovery/blob/a5d1029aec9c428a7ce7ae615621ea8915162824/app.py#L31.
     Credits to Mykola Kozyr.
 
     Args:
         url (str): A URL to a STAC catalog.
+        **kwargs: Additional keyword arguments to pass to the pystac Client.open() method.
+            See https://pystac-client.readthedocs.io/en/stable/api.html#pystac_client.Client.open
 
     Returns:
         list: A list of STAC collections.
@@ -3861,7 +3863,7 @@ def get_stac_collections(url):
     # Expensive function. Added cache for it.
 
     # Empty list that would be used for a dataframe to collect and visualize info about collections
-    root_catalog = Client.open(url)
+    root_catalog = Client.open(url, **kwargs)
     collections_list = []
     # Reading collections in the Catalog
     collections = list(root_catalog.get_collections())
@@ -3886,6 +3888,7 @@ def get_stac_items(
     datetime=None,
     intersects=None,
     ids=None,
+    open_args=None,
     **kwargs,
 ):
     """Retrieve a list of STAC items from a URL and a collection.
@@ -3901,6 +3904,8 @@ def get_stac_items(
         datetime (str, optional): Single date+time, or a range ('/' separator), formatted to RFC 3339, section 5.6. Use double dots .. for open date ranges.
         intersects (dict, optional): A dictionary representing a GeoJSON Geometry. Searches items by performing intersection between their geometry and provided GeoJSON geometry. All GeoJSON geometry types must be supported.
         ids (list, optional): A list of item ids to return.
+        open_args (dict, optional): A dictionary of arguments to pass to the pystac Client.open() method. Defaults to None.
+        **kwargs: Additional keyword arguments to pass to the Catalog.search() method.
 
     Returns:
         GeoPandas.GeoDataFraem: A GeoDataFrame with the STAC items.
@@ -3913,6 +3918,10 @@ def get_stac_items(
 
     # Empty list that would be used for a dataframe to collect and visualize info about collections
     items_list = []
+
+    if open_args is None:
+        open_args = {}
+
     root_catalog = Client.open(url)
 
     if limit:

--- a/leafmap/stac.py
+++ b/leafmap/stac.py
@@ -996,17 +996,18 @@ def stac_pixel_value(
         return result
 
 
-def stac_object_type(url):
+def stac_object_type(url, **kwargs):
     """Get the STAC object type.
 
     Args:
         url (str): The STAC object URL.
+        **kwargs: Keyword arguments for pystac.STACObject.from_file(). Defaults to None.
 
     Returns:
         str: The STAC object type, can be catalog, collection, or item.
     """
     try:
-        obj = pystac.STACObject.from_file(url)
+        obj = pystac.STACObject.from_file(url, **kwargs)
 
         if isinstance(obj, pystac.Collection):
             return "collection"
@@ -1020,19 +1021,20 @@ def stac_object_type(url):
         return None
 
 
-def stac_root_link(url, return_col_id=False):
+def stac_root_link(url, return_col_id=False, **kwargs):
     """Get the root link of a STAC object.
 
     Args:
         url (str): The STAC object URL.
         return_col_id (bool, optional): Return the collection ID if the STAC object is a collection. Defaults to False.
+        **kwargs: Keyword arguments for pystac.STACObject.from_file(). Defaults to None.
 
     Returns:
         str: The root link of the STAC object.
     """
     collection_id = None
     try:
-        obj = pystac.STACObject.from_file(url)
+        obj = pystac.STACObject.from_file(url, **kwargs)
         if isinstance(obj, pystac.Collection):
             collection_id = obj.id
         href = obj.get_root_link().get_href()
@@ -1461,11 +1463,12 @@ def set_default_bands(bands):
         return bands[:3]
 
 
-def maxar_collections(return_ids=True):
+def maxar_collections(return_ids=True, **kwargs):
     """Get a list of Maxar collections.
 
     Args:
         return_ids (bool, optional): Whether to return the collection ids. Defaults to True.
+        **kwargs: Additional keyword arguments to pass to the pystac Catalog.from_file() method.
 
     Returns:
         list : A list of Maxar collections.
@@ -1491,7 +1494,7 @@ def maxar_collections(return_ids=True):
     else:
         url = "https://maxar-opendata.s3.amazonaws.com/events/catalog.json"
 
-    root_catalog = Catalog.from_file(url)
+    root_catalog = Catalog.from_file(url, **kwargs)
 
     collections = root_catalog.get_collections()
 
@@ -1505,13 +1508,14 @@ def maxar_collections(return_ids=True):
     return collections
 
 
-def maxar_child_collections(collection_id, return_ids=True):
+def maxar_child_collections(collection_id, return_ids=True, **kwargs):
     """Get a list of Maxar child collections.
 
     Args:
         collection_id (str): The collection ID, e.g., Kahramanmaras-turkey-earthquake-23
             Use maxar_collections() to retrieve all available collection IDs.
         return_ids (bool, optional): Whether to return the collection ids. Defaults to True.
+        **kwargs: Additional keyword arguments to pass to the pystac Catalog.from_file() method.
 
     Returns:
         list: A list of Maxar child collections.
@@ -1531,7 +1535,7 @@ def maxar_child_collections(collection_id, return_ids=True):
     else:
         url = "https://maxar-opendata.s3.amazonaws.com/events/catalog.json"
 
-    root_catalog = Catalog.from_file(url)
+    root_catalog = Catalog.from_file(url, **kwargs)
 
     collections = root_catalog.get_child(collection_id).get_collections()
 
@@ -1545,7 +1549,7 @@ def maxar_child_collections(collection_id, return_ids=True):
         return collections
 
 
-def maxar_items(collection_id, child_id, return_gdf=True, assets=["visual"]):
+def maxar_items(collection_id, child_id, return_gdf=True, assets=["visual"], **kwargs):
     """Retrieve STAC items from Maxar's public STAC API.
 
     Args:
@@ -1556,6 +1560,7 @@ def maxar_items(collection_id, child_id, return_gdf=True, assets=["visual"]):
         return_gdf (bool, optional): If True, return a GeoDataFrame. Defaults to True.
         assets (list, optional): A list of asset names to include in the GeoDataFrame.
             It can be "visual", "ms_analytic", "pan_analytic", "data-mask". Defaults to ['visual'].
+        **kwargs: Additional keyword arguments to pass to the pystac Catalog.from_file() method.
 
     Returns:
         GeoDataFrame | pystac.ItemCollection: If return_gdf is True, return a GeoDataFrame.
@@ -1606,7 +1611,7 @@ def maxar_items(collection_id, child_id, return_gdf=True, assets=["visual"]):
     else:
         url = "https://maxar-opendata.s3.amazonaws.com/events/catalog.json"
 
-    root_catalog = Catalog.from_file(url)
+    root_catalog = Catalog.from_file(url, **kwargs)
 
     collection = root_catalog.get_child(collection_id)
     child = collection.get_child(child_id)
@@ -1646,7 +1651,9 @@ def maxar_items(collection_id, child_id, return_gdf=True, assets=["visual"]):
         return items
 
 
-def maxar_all_items(collection_id, return_gdf=True, assets=["visual"], verbose=True):
+def maxar_all_items(
+    collection_id, return_gdf=True, assets=["visual"], verbose=True, **kwargs
+):
     """Retrieve STAC items from Maxar's public STAC API.
 
     Args:
@@ -1655,18 +1662,20 @@ def maxar_all_items(collection_id, return_gdf=True, assets=["visual"], verbose=T
         return_gdf (bool, optional): If True, return a GeoDataFrame. Defaults to True.
         assets (list, optional): A list of asset names to include in the GeoDataFrame.
             It can be "visual", "ms_analytic", "pan_analytic", "data-mask". Defaults to ['visual'].
+        verbose (bool, optional): If True, print progress. Defaults to True.
+        **kwargs: Additional keyword arguments to pass to the pystac Catalog.from_file() method.
 
     Returns:
         GeoDataFrame | pystac.ItemCollection: If return_gdf is True, return a GeoDataFrame.
     """
 
-    child_ids = maxar_child_collections(collection_id)
+    child_ids = maxar_child_collections(collection_id, **kwargs)
     for index, child_id in enumerate(child_ids):
         if verbose:
             print(
                 f"Processing ({str(index+1).zfill(len(str(len(child_ids))))} out of {len(child_ids)}): {child_id} ..."
             )
-        items = maxar_items(collection_id, child_id, return_gdf, assets)
+        items = maxar_items(collection_id, child_id, return_gdf, assets, **kwargs)
         if return_gdf:
             if child_id == child_ids[0]:
                 gdf = items

--- a/leafmap/stac.py
+++ b/leafmap/stac.py
@@ -1059,7 +1059,10 @@ def stac_client(
     parameters=None,
     ignore_conformance=False,
     modifier=None,
+    request_modifier=None,
+    stac_io=None,
     return_col_id=False,
+    **kwargs,
 ):
     """Get the STAC client. It wraps the pystac.Client.open() method. See
         https://pystac-client.readthedocs.io/en/stable/api.html#pystac_client.Client.open
@@ -1076,7 +1079,17 @@ def stac_client(
         modifier (function, optional): A callable that modifies the children collection and items
             returned by this Client. This can be useful for injecting authentication parameters
             into child assets to access data from non-public sources. Defaults to None.
+        request_modifier (function, optional): A callable that either modifies a Request instance or returns
+            a new one. This can be useful for injecting Authentication headers and/or signing fully-formed
+            requests (e.g. signing requests using AWS SigV4). The callable should expect a single argument,
+            which will be an instance of requests.Request. If the callable returns a requests.Request, that
+            will be used. Alternately, the callable may simply modify the provided request object and
+            return None.
+        stac_io (pystac.STAC_IO, optional): A StacApiIO object to use for I/O requests. Generally, leave
+            this to the default. However in cases where customized I/O processing is required, a custom
+            instance can be provided here.
         return_col_id (bool, optional): Return the collection ID. Defaults to False.
+        **kwargs: Additional keyword arguments to pass to the pystac.Client.open() method.
 
     Returns:
         pystac.Client: The STAC client.
@@ -1090,13 +1103,27 @@ def stac_client(
 
         if return_col_id:
             client = Client.open(
-                root[0], headers, parameters, ignore_conformance, modifier
+                root[0],
+                headers,
+                parameters,
+                ignore_conformance,
+                modifier,
+                request_modifier,
+                stac_io,
+                **kwargs,
             )
             collection_id = root[1]
             return client, collection_id
         else:
             client = Client.open(
-                root, headers, parameters, ignore_conformance, modifier
+                root,
+                headers,
+                parameters,
+                ignore_conformance,
+                modifier,
+                request_modifier,
+                stac_io,
+                **kwargs,
             )
             return client
 
@@ -1105,18 +1132,19 @@ def stac_client(
         return None
 
 
-def stac_collections(url, return_ids=False):
+def stac_collections(url, return_ids=False, **kwargs):
     """Get the collection IDs of a STAC catalog.
 
     Args:
         url (str): The STAC catalog URL.
         return_ids (bool, optional): Return collection IDs. Defaults to False.
+        **kwargs: Additional keyword arguments to pass to the stac_client() method.
 
     Returns:
         list: A list of collection IDs.
     """
     try:
-        client = stac_client(url)
+        client = stac_client(url, **kwargs)
         collections = client.get_all_collections()
 
         if return_ids:


### PR DESCRIPTION
This PR improves the `stac_client` function by adding additional parameters such as `request_modifier` and `stac_io` that are supported by the `pystac.Client.open()` method. 
https://pystac-client.readthedocs.io/en/stable/api.html#pystac_client.Client.open

AWS SigV4
https://github.com/stac-utils/pystac-client/blob/main/docs/tutorials/authentication.md#aws-sigv4