### PR TITLE
Fix netcdf_to_tif to correctly shift longitude with custom variable name

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -4666,7 +4666,7 @@ def netcdf_to_tif(
 
     if shift_lon:
         xds.coords[lon] = (xds.coords[lon] + 180) % 360 - 180
-        xds = xds.sortby(xds.lon)
+        xds = xds.sortby(xds[lon])
 
     allowed_vars = list(xds.data_vars.keys())
     if isinstance(variables, str):


### PR DESCRIPTION
_lon_ was hard-coded as a variable name in the shifting logic, and was ignoring the variable being passed to the function. This fixes the bug.