### PR TITLE
Add support for PMTiles

### DIFF
--- a/docs/notebooks/82_pmtiles.ipynb
+++ b/docs/notebooks/82_pmtiles.ipynb
@@ -42,8 +42,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = leafmap.Map(center=[43.7798, 11.24148], zoom=13)\n",
     "url = \"https://open.gishub.org/data/pmtiles/protomaps_firenze.pmtiles\"\n",
+    "metadata = leafmap.pmtiles_metadata(url)\n",
+    "print(f\"layer names: {metadata['layer_names']}\")\n",
+    "print(f\"bounds: {metadata['bounds']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
     "\n",
     "style={\n",
     "    \"version\": 8,\n",
@@ -73,6 +84,7 @@
     "}\n",
     "\n",
     "m.add_pmtiles(url, name='PMTiles', style=style, overlay=True, show=True)\n",
+    "m.zoom_to_bounds(metadata['bounds'])\n",
     "m"
    ]
   },
@@ -89,9 +101,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = leafmap.Map(center=[52.963529, 4.756306], zoom=15, height='800px')\n",
-    "m.add_basemap('CartoDB.DarkMatter')\n",
     "url = \"https://storage.googleapis.com/ahp-research/overture/pmtiles/overture.pmtiles\"\n",
+    "metadata = leafmap.pmtiles_metadata(url)\n",
+    "print(f\"layer names: {metadata['layer_names']}\")\n",
+    "print(f\"bounds: {metadata['bounds']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(height='800px')\n",
+    "m.add_basemap('CartoDB.DarkMatter')\n",
     "\n",
     "style={\n",
     "    \"version\": 8,\n",
@@ -145,6 +168,7 @@
     "\n",
     "m.add_legend(legend_dict=legend_dict)\n",
     "\n",
+    "m.zoom_to_bounds(metadata['bounds'])\n",
     "m"
    ]
   }
@@ -165,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/82_pmtiles.ipynb
+++ b/docs/notebooks/82_pmtiles.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "m = leafmap.Map()\n",
     "\n",
-    "style={\n",
+    "style = {\n",
     "    \"version\": 8,\n",
     "    \"sources\": {\n",
     "        \"example_source\": {\n",
@@ -83,8 +83,9 @@
     "    ],\n",
     "}\n",
     "\n",
-    "m.add_pmtiles(url, name='PMTiles', style=style, overlay=True, show=True)\n",
-    "m.zoom_to_bounds(metadata['bounds'])\n",
+    "m.add_pmtiles(\n",
+    "    url, name='PMTiles', style=style, overlay=True, show=True, zoom_to_layer=True\n",
+    ")\n",
     "m"
    ]
   },
@@ -116,7 +117,7 @@
     "m = leafmap.Map(height='800px')\n",
     "m.add_basemap('CartoDB.DarkMatter')\n",
     "\n",
-    "style={\n",
+    "style = {\n",
     "    \"version\": 8,\n",
     "    \"sources\": {\n",
     "        \"example_source\": {\n",
@@ -157,7 +158,9 @@
     "    ],\n",
     "}\n",
     "\n",
-    "m.add_pmtiles(url, name='PMTiles', style=style, overlay=True, show=True)\n",
+    "m.add_pmtiles(\n",
+    "    url, name='PMTiles', style=style, overlay=True, show=True, zoom_to_layer=True\n",
+    ")\n",
     "\n",
     "legend_dict = {\n",
     "    'admins': 'BDD3C7',\n",
@@ -167,8 +170,6 @@
     "}\n",
     "\n",
     "m.add_legend(legend_dict=legend_dict)\n",
-    "\n",
-    "m.zoom_to_bounds(metadata['bounds'])\n",
     "m"
    ]
   }

--- a/examples/notebooks/82_pmtiles.ipynb
+++ b/examples/notebooks/82_pmtiles.ipynb
@@ -42,8 +42,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = leafmap.Map(center=[43.7798, 11.24148], zoom=13)\n",
     "url = \"https://open.gishub.org/data/pmtiles/protomaps_firenze.pmtiles\"\n",
+    "metadata = leafmap.pmtiles_metadata(url)\n",
+    "print(f\"layer names: {metadata['layer_names']}\")\n",
+    "print(f\"bounds: {metadata['bounds']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
     "\n",
     "style={\n",
     "    \"version\": 8,\n",
@@ -73,6 +84,7 @@
     "}\n",
     "\n",
     "m.add_pmtiles(url, name='PMTiles', style=style, overlay=True, show=True)\n",
+    "m.zoom_to_bounds(metadata['bounds'])\n",
     "m"
    ]
   },
@@ -89,9 +101,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = leafmap.Map(center=[52.963529, 4.756306], zoom=15, height='800px')\n",
-    "m.add_basemap('CartoDB.DarkMatter')\n",
     "url = \"https://storage.googleapis.com/ahp-research/overture/pmtiles/overture.pmtiles\"\n",
+    "metadata = leafmap.pmtiles_metadata(url)\n",
+    "print(f\"layer names: {metadata['layer_names']}\")\n",
+    "print(f\"bounds: {metadata['bounds']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(height='800px')\n",
+    "m.add_basemap('CartoDB.DarkMatter')\n",
     "\n",
     "style={\n",
     "    \"version\": 8,\n",
@@ -145,6 +168,7 @@
     "\n",
     "m.add_legend(legend_dict=legend_dict)\n",
     "\n",
+    "m.zoom_to_bounds(metadata['bounds'])\n",
     "m"
    ]
   }
@@ -165,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/82_pmtiles.ipynb
+++ b/examples/notebooks/82_pmtiles.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "m = leafmap.Map()\n",
     "\n",
-    "style={\n",
+    "style = {\n",
     "    \"version\": 8,\n",
     "    \"sources\": {\n",
     "        \"example_source\": {\n",
@@ -83,8 +83,9 @@
     "    ],\n",
     "}\n",
     "\n",
-    "m.add_pmtiles(url, name='PMTiles', style=style, overlay=True, show=True)\n",
-    "m.zoom_to_bounds(metadata['bounds'])\n",
+    "m.add_pmtiles(\n",
+    "    url, name='PMTiles', style=style, overlay=True, show=True, zoom_to_layer=True\n",
+    ")\n",
     "m"
    ]
   },
@@ -116,7 +117,7 @@
     "m = leafmap.Map(height='800px')\n",
     "m.add_basemap('CartoDB.DarkMatter')\n",
     "\n",
-    "style={\n",
+    "style = {\n",
     "    \"version\": 8,\n",
     "    \"sources\": {\n",
     "        \"example_source\": {\n",
@@ -157,7 +158,9 @@
     "    ],\n",
     "}\n",
     "\n",
-    "m.add_pmtiles(url, name='PMTiles', style=style, overlay=True, show=True)\n",
+    "m.add_pmtiles(\n",
+    "    url, name='PMTiles', style=style, overlay=True, show=True, zoom_to_layer=True\n",
+    ")\n",
     "\n",
     "legend_dict = {\n",
     "    'admins': 'BDD3C7',\n",
@@ -167,8 +170,6 @@
     "}\n",
     "\n",
     "m.add_legend(legend_dict=legend_dict)\n",
-    "\n",
-    "m.zoom_to_bounds(metadata['bounds'])\n",
     "m"
    ]
   }

--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -217,6 +217,7 @@ class Map(folium.Map):
         overlay=True,
         control=True,
         show=True,
+        zoom_to_layer=True,
         **kwargs,
     ):
         """
@@ -229,6 +230,7 @@ class Map(folium.Map):
             overlay (bool, optional): Whether the layer should be added as an overlay. Defaults to True.
             control (bool, optional): Whether to include the layer in the layer control. Defaults to True.
             show (bool, optional): Whether the layer should be shown initially. Defaults to True.
+            zoom_to_layer (bool, optional): Whether to zoom to the layer extent. Defaults to True.
             **kwargs: Additional keyword arguments to pass to the PMTilesLayer constructor.
 
         Returns:
@@ -245,6 +247,11 @@ class Map(folium.Map):
             **kwargs,
         )
         self.add_child(layer)
+
+        if zoom_to_layer:
+            metadata = pmtiles_metadata(url)
+            bounds = metadata["bounds"]
+            self.zoom_to_bounds(bounds)
 
     def add_layer_control(self):
         """Adds layer control to the map."""

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -26,6 +26,7 @@ owslib
 palettable
 panel
 plotly
+pmtiles
 psycopg2
 pycrs
 pydeck
@@ -37,5 +38,6 @@ rio-cogeo
 rioxarray
 sqlalchemy
 streamlit-folium
+# tippecanoe
 xarray_leaflet         
 PyYAML==6.0.1


### PR DESCRIPTION
Add functions for converting vector data to mbtiles and pmtiles; get pmtiles header and metadata, such as layer names, center, bounds, etc. 

```python
import leafmap

url = "https://storage.googleapis.com/ahp-research/overture/pmtiles/overture.pmtiles"
metadata = leafmap.pmtiles_metadata(url)
print(metadata['layer_names'])
print(metadata['bounds'])
print(metadata['center'])
```