### PR TITLE
Add ipyleaflet support for PMTiles

### DIFF
--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -592,6 +592,56 @@ class Map(ipyleaflet.Map):
 
     add_vector_tile_layer = add_vector_tile
 
+    def add_pmtiles(
+        self,
+        url,
+        style={},
+        name="PMTiles",
+        show=True,
+        zoom_to_layer=True,
+        **kwargs,
+    ):
+        """
+        Adds a PMTiles layer to the map. This function is not officially supported yet by ipyleaflet yet.
+        Install it with the following command:
+        pip install git+https://github.com/giswqs/ipyleaflet.git@pmtiles
+
+        Args:
+            url (str): The URL of the PMTiles file.
+            style (str, optional): The CSS style to apply to the layer. Defaults to None.
+                See https://docs.mapbox.com/style-spec/reference/layers/ for more info.
+            name (str, optional): The name of the layer. Defaults to None.
+            show (bool, optional): Whether the layer should be shown initially. Defaults to True.
+            zoom_to_layer (bool, optional): Whether to zoom to the layer extent. Defaults to True.
+            **kwargs: Additional keyword arguments to pass to the PMTilesLayer constructor.
+
+        Returns:
+            None
+        """
+
+        try:
+            if "sources" in kwargs:
+                del kwargs["sources"]
+
+            if "version" in kwargs:
+                del kwargs["version"]
+
+            layer = ipyleaflet.PMTilesLayer(
+                url=url,
+                style=style,
+                name=name,
+                visible=show,
+                **kwargs,
+            )
+            self.add(layer)
+
+            if zoom_to_layer:
+                metadata = pmtiles_metadata(url)
+                bounds = metadata["bounds"]
+                self.zoom_to_bounds(bounds)
+        except Exception as e:
+            print(e)
+
     def add_osm_from_geocode(
         self,
         query,


### PR DESCRIPTION
This feature is not officially supported by ipyleaflet yet. Wait until this PR https://github.com/jupyter-widgets/ipyleaflet/pull/1138 is merged. For now, install it with the following command:

```bash
pip install git+https://github.com/giswqs/ipyleaflet.git@pmtiles
```

```python
from ipyleaflet import Map, basemaps, PMTilesLayer

m = Map(center=[52.963529, 4.776306], zoom=7, basemap=basemaps.CartoDB.DarkMatter, scroll_wheel_zoom=True)
m.layout.height = '600px'

vl = PMTilesLayer(url="https://storage.googleapis.com/ahp-research/overture/pmtiles/overture.pmtiles", 
    style = {
        "layers": [
            {
                "id": "admins",
                "source": "example_source",
                "source-layer": "admins",
                "type": "fill",
                "paint": {"fill-color": "#BDD3C7", "fill-opacity": 0.1},
            },
            {
                "id": "buildings",
                "source": "example_source",
                "source-layer": "buildings",
                "type": "fill",
                "paint": {"fill-color": "#FFFFB3", "fill-opacity": 0.5},
            },
            {
                "id": "places",
                "source": "example_source",
                "source-layer": "places",
                "type": "fill",
                "paint": {"fill-color": "#BEBADA", "fill-opacity": 0.5},
            },
            {
                "id": "roads",
                "source": "example_source",
                "source-layer": "roads",
                "type": "line",
                "paint": {"line-color": "#FB8072"},
            },
        ],
    })
m.add(vl)
m
```

https://github.com/jupyter-widgets/ipyleaflet/assets/5016453/45985dc8-6aa3-4159-925d-00afb2929a58

