### PR TITLE
Add wms legend method to Map class

### DIFF
--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -416,6 +416,41 @@ class Map(folium.Map):
             ).add_to(self)
         except Exception as e:
             raise Exception(e)
+        
+    def add_wms_legend(
+        self,
+        url,
+    ):
+        """Add a WMS legend based on an image URL
+
+        Args:
+            url (str): URL of the WMS legend image.
+        """
+        from branca.element import Figure, MacroElement, Element
+    
+        # Check if the map is a Folium Map instance
+        if not isinstance(self, Map):
+            raise ValueError("The self argument must be an instance of folium.Map.")
+
+        # HTML template for the legend
+        legend_html = f"""
+            {{% macro html(this, kwargs) %}}
+            
+            <div id="maplegend" style="position: fixed; 
+                        bottom: 50px;
+                        right: 50px;
+                        z-index:9999; 
+                        ">
+                <img src="{ url }" alt="legend" style="width: 100%; height: 100%;">
+            </div>
+            {{% endmacro %}}
+        """
+        
+        # Create an Element with the HTML and add it to the map
+        macro = MacroElement()
+        macro._template = Template(legend_html)
+
+        self.get_root().add_child(macro)
 
     def add_tile_layer(
         self,

--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -424,7 +424,7 @@ class Map(folium.Map):
         """Add a WMS legend based on an image URL
 
         Args:
-            url (str): URL of the WMS legend image.
+            url (str): URL of the WMS legend image. Should have this format if using wms legend: {geoserver}/wms?REQUEST=GetLegendGraphic&FORMAT=image/png&LAYER={layer}
         """
         from branca.element import Figure, MacroElement, Element
     

--- a/tests/test_foliumap.py
+++ b/tests/test_foliumap.py
@@ -153,6 +153,16 @@ class TestFoliumap(unittest.TestCase):
         out_str = m.to_html()
         assert "NLCD" in out_str
 
+    def test_add_wms_legend(self):
+        """Check add of wms legend based on url"""
+        m = leafmap.Map()
+        url="https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2016_Land_Cover_L48/wms?REQUEST=GetLegendGraphic&FORMAT=image/png&LAYER=NLCD_2016_Land_Cover_L48"
+        m.add_wms_legend(url=url)
+        out_str = m.to_html()
+        
+        assert "GetLegendGraphic" in out_str
+    
+
     # def test_add_marker_cluster(self):
     #     """Check marker cluster"""
     #     with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
I couldnt find any method to add a legend to a custom WMS legend into a Map. image_overlay is set to bounds, and builtin legends don't allow custom legends.

Perhaps I missed something, but if not, this might be a nice start for a add_wms_legend method
