### PR TITLE
Add tooltip for PMTiles

### DIFF
--- a/leafmap/__init__.py
+++ b/leafmap/__init__.py
@@ -63,7 +63,7 @@ def view_vector(
             **kwargs: Additional keyword arguments that will be passed to lonboard.Layer.from_geopandas()
 
     Returns:
-        None
+        lonboard.Map: A lonboard Map object.
     """
     from .deckgl import Map
 
@@ -79,6 +79,46 @@ def view_vector(
         color_args,
         open_args,
         **kwargs,
+    )
+    return m
+
+
+def view_pmtiles(
+    url,
+    style=None,
+    name=None,
+    tooltip=True,
+    overlay=True,
+    control=True,
+    show=True,
+    zoom_to_layer=True,
+    map_args={},
+    **kwargs,
+):
+    """
+    Visualize PMTiles the map.
+
+    Args:
+        url (str): The URL of the PMTiles file.
+        style (str, optional): The CSS style to apply to the layer. Defaults to None.
+            See https://docs.mapbox.com/style-spec/reference/layers/ for more info.
+        name (str, optional): The name of the layer. Defaults to None.
+        tooltip (bool, optional): Whether to show a tooltip when hovering over the layer. Defaults to True.
+        overlay (bool, optional): Whether the layer should be added as an overlay. Defaults to True.
+        control (bool, optional): Whether to include the layer in the layer control. Defaults to True.
+        show (bool, optional): Whether the layer should be shown initially. Defaults to True.
+        zoom_to_layer (bool, optional): Whether to zoom to the layer extent. Defaults to True.
+        **kwargs: Additional keyword arguments to pass to the PMTilesLayer constructor.
+
+    Returns:
+        folium.Map: A folium Map object.
+    """
+
+    from .foliumap import Map
+
+    m = Map(**map_args)
+    m.add_pmtiles(
+        url, style, name, tooltip, overlay, control, show, zoom_to_layer, **kwargs
     )
     return m
 

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -374,6 +374,38 @@ def show_html(html: str):
             raise Exception(e)
 
 
+def display_html(
+    html: Union[str, bytes], width: str = "100%", height: int = 500
+) -> None:
+    """
+    Displays an HTML file or HTML string in a Jupyter Notebook.
+
+    Args:
+        html (Union[str, bytes]): Path to an HTML file or an HTML string.
+        width (str, optional): Width of the displayed iframe. Default is '100%'.
+        height (int, optional): Height of the displayed iframe. Default is 500.
+
+    Returns:
+        None
+    """
+    from IPython.display import IFrame, display
+
+    if isinstance(html, str) and html.startswith("<"):
+        # If the input is an HTML string
+        html_content = html
+    elif isinstance(html, str):
+        # If the input is a file path
+        with open(html, "r") as file:
+            html_content = file.read()
+    elif isinstance(html, bytes):
+        # If the input is a byte string
+        html_content = html.decode("utf-8")
+    else:
+        raise ValueError("Invalid input type. Expected a file path or an HTML string.")
+
+    display(IFrame(srcdoc=html_content, width=width, height=height))
+
+
 def has_transparency(img) -> bool:
     """Checks whether an image has transparency.
 


### PR DESCRIPTION
This PR adds the `tooltip` option for PMTiles. Fix #571 

Adapted from https://github.com/jtmiclat/folium-pmtiles/pull/13. Credits to jtmiclat.

```python
import leafmap 

style = {
    "version": 8,
    "sources": {
        "example_source": {
            "type": "vector",
            "url": "pmtiles://" + url,
            "attribution": 'PMTiles',
        }
    },
    "layers": [
        {
            "id": "buildings",
            "source": "example_source",
            "source-layer": "landuse",
            "type": "fill",
            "paint": {"fill-color": "steelblue"},
        },
        {
            "id": "roads",
            "source": "example_source",
            "source-layer": "roads",
            "type": "line",
            "paint": {"line-color": "black"},
        },
    ],
}

leafmap.view_pmtiles(
    url, 
    name='PMTiles', 
    style=style, 
    zoom_to_layer=True, 
    tooltip=True, 
    map_args={'height': 600}
)
```
![image](https://github.com/opengeos/leafmap/assets/5016453/41e16eb7-5b6c-485a-b2cb-64a5b9f33026)

@jinha This might be of interest to you. 
