### PR TITLE
Add font size option for circle marker

### DIFF
--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -2359,6 +2359,7 @@ class Map(folium.Map):
         tooltip: Optional[List] = None,
         min_width: Optional[int] = 100,
         max_width: Optional[int] = 200,
+        font_size: Optional[int] = 2,
         **kwargs,
     ):
         """Adds a marker cluster to the map.
@@ -2372,6 +2373,7 @@ class Map(folium.Map):
             tooltip (list, optional): A list of column names to be used as the tooltip. Defaults to None.
             min_width (int, optional): The minimum width of the popup. Defaults to 100.
             max_width (int, optional): The maximum width of the popup. Defaults to 200.
+            font_size (int, optional): The font size of the popup. Defaults to 2.
 
         """
         import pandas as pd
@@ -2413,13 +2415,29 @@ class Map(folium.Map):
         for idx, row in df.iterrows():
             html = ""
             for p in popup:
-                html = html + "<b>" + p + "</b>" + ": " + str(row[p]) + "<br>"
+                html = (
+                    html
+                    + f"<font size='{font_size}'><b>"
+                    + p
+                    + "</b>"
+                    + ": "
+                    + str(row[p])
+                    + "<br></font>"
+                )
             popup_html = folium.Popup(html, min_width=min_width, max_width=max_width)
 
             if tooltip is not None:
                 html = ""
                 for p in tooltip:
-                    html = html + "<b>" + p + "</b>" + ": " + str(row[p]) + "<br>"
+                    html = (
+                        html
+                        + f"<font size='{font_size}'><b>"
+                        + p
+                        + "</b>"
+                        + ": "
+                        + str(row[p])
+                        + "<br></font>"
+                    )
 
                 tooltip_str = folium.Tooltip(html)
             else:

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -1148,6 +1148,7 @@ class Map(ipyleaflet.Map):
         y="latitude",
         radius=10,
         popup=None,
+        font_size=2,
         **kwargs,
     ):
         """Adds a marker cluster to the map. For a list of options, see https://ipyleaflet.readthedocs.io/en/latest/api_reference/circle_marker.html
@@ -1158,6 +1159,7 @@ class Map(ipyleaflet.Map):
             y (str, optional): The column name for the y values. Defaults to "latitude".
             radius (int, optional): The radius of the circle. Defaults to 10.
             popup (list, optional): A list of column names to be used as the popup. Defaults to None.
+            font_size (int, optional): The font size of the popup. Defaults to 2.
 
         """
         import pandas as pd
@@ -1186,7 +1188,15 @@ class Map(ipyleaflet.Map):
         for idx, row in df.iterrows():
             html = ""
             for p in popup:
-                html = html + "<b>" + p + "</b>" + ": " + str(row[p]) + "<br>"
+                html = (
+                    html
+                    + f"<font size='{font_size}'><b>"
+                    + p
+                    + "</b>"
+                    + ": "
+                    + str(row[p])
+                    + "<br></font>"
+                )
             popup_html = widgets.HTML(html)
 
             marker = ipyleaflet.CircleMarker(


### PR DESCRIPTION
Fix #627

```python
import leafmap.foliumap as leafmap

m = leafmap.Map(center=[40, -100], zoom=4)
data = "https://raw.githubusercontent.com/opengeos/leafmap/master/examples/data/us_cities.csv"
m.add_circle_markers_from_xy(
    data, x="longitude", y="latitude", radius=10, color="blue", fill_color="black", font_size=5
)
m
```
![image](https://github.com/opengeos/leafmap/assets/5016453/fb4c5f12-e342-4af7-b7c3-6fc3b481a2fa)

