### PR TITLE
Add support for downloading NASA Earth data

### DIFF
--- a/docs/notebooks/88_nasa_earth_data.ipynb
+++ b/docs/notebooks/88_nasa_earth_data.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=notebooks/88_nasa_earth_data.ipynb)\n",
+    "[![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/88_nasa_earth_data.ipynb)\n",
+    "[![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/88_nasa_earth_data.ipynb&branch=master)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/examples/notebooks/88_nasa_earth_data.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)\n",
+    "\n",
+    "**Searching and downloading NASA Earth science data products**\n",
+    "\n",
+    "Leafmap builds upon the [earthaccess](https://earthaccess.readthedocs.io) Python package to search and download NASA Earth science data products, making it easier visualize the footprints of the data products and download them interactively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import leafmap\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To download and access the data, you will need to create an Earthdata login. You can register for an account at [urs.earthdata.nasa.gov](https://urs.earthdata.nasa.gov)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leafmap.nasa_data_login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can search data by short name, doi, concept id, etc. You can find the list of NASA Earth science data products from the [NASA-Earth-Data](https://github.com/opengeos/NASA-Earth-Data) repo. The example below shows how to show the metadata of the 9,000+ NASA Earth science data products."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://github.com/opengeos/NASA-Earth-Data/raw/main/nasa_earth_data.tsv'\n",
+    "df = pd.read_csv(url, sep='\\t')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To search data, specify the short name, bounding box, date range, etc. To return the footprints of the data, set `return_gdf=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results, gdf = leafmap.nasa_data_search(\n",
+    "    short_name='GEDI_L4A_AGB_Density_V2_1_2056',\n",
+    "    cloud_hosted=True,\n",
+    "    bounding_box=(-73.9872, -33.7683, -34.7299, 5.2444),\n",
+    "    temporal=(\"2020-07-01\", \"2020-07-31\"),\n",
+    "    count=-1,   # use -1 to return all datasets\n",
+    "    return_gdf=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize the footprints of the data on an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf.explore()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download the data to your local drive. Let's download the first 5 data products."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leafmap.nasa_data_download(results[:5], out_dir=\"data\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -101,6 +101,7 @@
 85. How to search and download GEDI L4A dataset interactively ([notebook](https://leafmap.org/notebooks/85_gedi))
 86. Adding markers to the map ([notebook](https://leafmap.org/notebooks/86_add_markers))
 87. Cloud-based geoprocessing with Actinia ([notebook](https://leafmap.org/notebooks/87_actinia))
+88. Searching and downloading NASA Earth science data products ([notebook](https://leafmap.org/notebooks/88_nasa_earth_data))
 
 ## Demo
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,6 +108,7 @@
 85. How to search and download GEDI L4A dataset interactively ([notebook](https://leafmap.org/notebooks/85_gedi))
 86. Adding markers to the map ([notebook](https://leafmap.org/notebooks/86_add_markers))
 87. Cloud-based geoprocessing with Actinia ([notebook](https://leafmap.org/notebooks/87_actinia))
+88. Searching and downloading NASA Earth science data products ([notebook](https://leafmap.org/notebooks/88_nasa_earth_data))
 
 ## Demo
 

--- a/examples/notebooks/88_nasa_earth_data.ipynb
+++ b/examples/notebooks/88_nasa_earth_data.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=notebooks/88_nasa_earth_data.ipynb)\n",
+    "[![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/88_nasa_earth_data.ipynb)\n",
+    "[![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/88_nasa_earth_data.ipynb&branch=master)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/examples/notebooks/88_nasa_earth_data.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)\n",
+    "\n",
+    "**Searching and downloading NASA Earth science data products**\n",
+    "\n",
+    "Leafmap builds upon the [earthaccess](https://earthaccess.readthedocs.io) Python package to search and download NASA Earth science data products, making it easier visualize the footprints of the data products and download them interactively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import leafmap\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To download and access the data, you will need to create an Earthdata login. You can register for an account at [urs.earthdata.nasa.gov](https://urs.earthdata.nasa.gov)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leafmap.nasa_data_login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can search data by short name, doi, concept id, etc. You can find the list of NASA Earth science data products from the [NASA-Earth-Data](https://github.com/opengeos/NASA-Earth-Data) repo. The example below shows how to show the metadata of the 9,000+ NASA Earth science data products."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://github.com/opengeos/NASA-Earth-Data/raw/main/nasa_earth_data.tsv'\n",
+    "df = pd.read_csv(url, sep='\\t')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To search data, specify the short name, bounding box, date range, etc. To return the footprints of the data, set `return_gdf=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results, gdf = leafmap.nasa_data_search(\n",
+    "    short_name='GEDI_L4A_AGB_Density_V2_1_2056',\n",
+    "    cloud_hosted=True,\n",
+    "    bounding_box=(-73.9872, -33.7683, -34.7299, 5.2444),\n",
+    "    temporal=(\"2020-07-01\", \"2020-07-31\"),\n",
+    "    count=-1,   # use -1 to return all datasets\n",
+    "    return_gdf=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize the footprints of the data on an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf.explore()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download the data to your local drive. Let's download the first 5 data products."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leafmap.nasa_data_download(results[:5], out_dir=\"data\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -223,3 +223,4 @@ nav:
           - notebooks/85_gedi.ipynb
           - notebooks/86_add_markers.ipynb
           - notebooks/87_actinia.ipynb
+          - notebooks/88_nasa_earth_data.ipynb

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ codespell
 cogeo-mosaic
 # datapane
 deadlink
+earthaccess
 ffmpeg-python
 geopandas
 googledrivedownloader


### PR DESCRIPTION
This PR adds support for searching and downloading NASA Earth data with the [earthaccess](https://github.com/nsidc/earthaccess) Python package, making it easier to visualize the footprints of the data products. Visualizing the imagery is coming soon. 

@BriannaLind @betolink @mfisher87

Fix #620 

```python
results, gdf = leafmap.nasa_data_search(
    short_name='GEDI_L4A_AGB_Density_V2_1_2056',
    cloud_hosted=True,
    bounding_box=(-73.9872, -33.7683, -34.7299, 5.2444),
    temporal=("2020-07-01", "2020-07-31"),
    count=-1,   # use -1 to return all datasets
    return_gdf=True
)
gdf.explore()
```

![image](https://github.com/opengeos/leafmap/assets/5016453/20232837-b5f4-46b5-a672-af58f6f1252e)
