### PR TITLE
Add support for visualizing in-memory raster

### DIFF
--- a/docs/notebooks/88_nasa_earth_data.ipynb
+++ b/docs/notebooks/88_nasa_earth_data.ipynb
@@ -124,7 +124,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e232fb9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/notebooks/89_image_array_viz.ipynb
+++ b/docs/notebooks/89_image_array_viz.ipynb
@@ -1,0 +1,201 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=notebooks/89_image_array_viz.ipynb)\n",
+    "[![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/89_image_array_viz.ipynb)\n",
+    "[![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/89_image_array_viz.ipynb&branch=master)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/examples/notebooks/89_image_array_viz.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)\n",
+    "\n",
+    "**Visualizing in-memory raster datasets and image arrays**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install leafmap rasterio rioxarray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import leafmap\n",
+    "import rasterio\n",
+    "import rioxarray\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download two sample raster datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url1 = \"https://open.gishub.org/data/raster/landsat7.tif\"\n",
+    "url2 = \"https://open.gishub.org/data/raster/srtm90.tif\"\n",
+    "satellite = leafmap.download_file(url1, \"landsat7.tif\")\n",
+    "dem = leafmap.download_file(url2, \"srtm90.tif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Landsat image contains 3 bands: nir, red, and green. Let's calculate NDVI using the nir and red bands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = rasterio.open(satellite)\n",
+    "nir = dataset.read(1).astype(float)\n",
+    "red = dataset.read(2).astype(float)\n",
+    "ndvi = (nir - red) / (nir + red)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an in-memory raster dataset from the NDVI array and use the projection and extent of the Landsat image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ndvi_image = leafmap.array_to_image(ndvi, source=satellite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize the Landsat image and the NDVI image on the same map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m.add_raster(satellite, band=[1, 2, 3], nodata=-1, layer_name=\"Landsat 7\")\n",
+    "m.add_raster(ndvi_image, cmap=\"Greens\", layer_name=\"NDVI\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use rioxarray to read raster datasets into xarray DataArrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = rioxarray.open_rasterio(dem)\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Classify the DEM into 2 elevation classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "array = ds.sel(band=1)\n",
+    "masked_array = xr.where(array < 2000, 0, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an in-memory raster dataset from the elevation class array and use the projection and extent of the DEM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = leafmap.array_to_image(masked_array, source=dem)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize the DEM and the elevation class image on the same map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m.add_raster(dem, cmap=\"terrain\", layer_name=\"DEM\")\n",
+    "m.add_raster(image, cmap=\"coolwarm\", layer_name=\"Classified DEM\")\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -102,6 +102,7 @@
 86. Adding markers to the map ([notebook](https://leafmap.org/notebooks/86_add_markers))
 87. Cloud-based geoprocessing with Actinia ([notebook](https://leafmap.org/notebooks/87_actinia))
 88. Searching and downloading NASA Earth science data products ([notebook](https://leafmap.org/notebooks/88_nasa_earth_data))
+89. Visualizing in-memory raster datasets and image arrays ([notebook](https://leafmap.org/notebooks/89_image_array_viz))
 
 ## Demo
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -109,6 +109,7 @@
 86. Adding markers to the map ([notebook](https://leafmap.org/notebooks/86_add_markers))
 87. Cloud-based geoprocessing with Actinia ([notebook](https://leafmap.org/notebooks/87_actinia))
 88. Searching and downloading NASA Earth science data products ([notebook](https://leafmap.org/notebooks/88_nasa_earth_data))
+89. Visualizing in-memory raster datasets and image arrays ([notebook](https://leafmap.org/notebooks/89_image_array_viz))
 
 ## Demo
 

--- a/examples/notebooks/88_nasa_earth_data.ipynb
+++ b/examples/notebooks/88_nasa_earth_data.ipynb
@@ -124,7 +124,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e232fb9",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/89_image_array_viz.ipynb
+++ b/examples/notebooks/89_image_array_viz.ipynb
@@ -1,0 +1,201 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=notebooks/89_image_array_viz.ipynb)\n",
+    "[![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/89_image_array_viz.ipynb)\n",
+    "[![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/89_image_array_viz.ipynb&branch=master)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/examples/notebooks/89_image_array_viz.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)\n",
+    "\n",
+    "**Visualizing in-memory raster datasets and image arrays**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install leafmap rasterio rioxarray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import leafmap\n",
+    "import rasterio\n",
+    "import rioxarray\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download two sample raster datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url1 = \"https://open.gishub.org/data/raster/landsat7.tif\"\n",
+    "url2 = \"https://open.gishub.org/data/raster/srtm90.tif\"\n",
+    "satellite = leafmap.download_file(url1, \"landsat7.tif\")\n",
+    "dem = leafmap.download_file(url2, \"srtm90.tif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Landsat image contains 3 bands: nir, red, and green. Let's calculate NDVI using the nir and red bands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = rasterio.open(satellite)\n",
+    "nir = dataset.read(1).astype(float)\n",
+    "red = dataset.read(2).astype(float)\n",
+    "ndvi = (nir - red) / (nir + red)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an in-memory raster dataset from the NDVI array and use the projection and extent of the Landsat image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ndvi_image = leafmap.array_to_image(ndvi, source=satellite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize the Landsat image and the NDVI image on the same map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m.add_raster(satellite, band=[1, 2, 3], nodata=-1, layer_name=\"Landsat 7\")\n",
+    "m.add_raster(ndvi_image, cmap=\"Greens\", layer_name=\"NDVI\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use rioxarray to read raster datasets into xarray DataArrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = rioxarray.open_rasterio(dem)\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Classify the DEM into 2 elevation classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "array = ds.sel(band=1)\n",
+    "masked_array = xr.where(array < 2000, 0, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an in-memory raster dataset from the elevation class array and use the projection and extent of the DEM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = leafmap.array_to_image(masked_array, source=dem)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize the DEM and the elevation class image on the same map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m.add_raster(dem, cmap=\"terrain\", layer_name=\"DEM\")\n",
+    "m.add_raster(image, cmap=\"coolwarm\", layer_name=\"Classified DEM\")\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -72,7 +72,7 @@ class Map(ipyleaflet.Map):
                 self.sandbox_path = None
 
         if "height" not in kwargs:
-            self.layout.height = "500px"
+            self.layout.height = "600px"
         else:
             if isinstance(kwargs["height"], int):
                 kwargs["height"] = str(kwargs["height"]) + "px"
@@ -93,7 +93,7 @@ class Map(ipyleaflet.Map):
             self.add(ipyleaflet.FullScreenControl())
 
         if "search_control" not in kwargs:
-            kwargs["search_control"] = True
+            kwargs["search_control"] = False
         if kwargs["search_control"]:
             url = "https://nominatim.openstreetmap.org/search?format=json&q={s}"
             search_control = ipyleaflet.SearchControl(
@@ -180,7 +180,7 @@ class Map(ipyleaflet.Map):
             draw_control.on_draw(handle_draw)
 
         if "measure_control" not in kwargs:
-            kwargs["measure_control"] = True
+            kwargs["measure_control"] = False
         if kwargs["measure_control"]:
             self.add(ipyleaflet.MeasureControl(position="topleft"))
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,3 +224,4 @@ nav:
           - notebooks/86_add_markers.ipynb
           - notebooks/87_actinia.ipynb
           - notebooks/88_nasa_earth_data.ipynb
+          - notebooks/89_image_array_viz.ipynb


### PR DESCRIPTION
Add support for visualizing in-memory raster datasets, e.g., numpy.ndarray and xarray.DataArray. Fix #650. 

![Peek 2023-12-23 23-12](https://github.com/opengeos/leafmap/assets/5016453/f2c05d39-af72-460e-b7f2-a01fa6426b9c)

![Peek 2023-12-23 23-13](https://github.com/opengeos/leafmap/assets/5016453/29c1db75-81b1-477c-a968-33927c36f772)
