### PR TITLE
Modified add_velocity in leafmap.py to support custom color list

### DIFF
--- a/examples/notebooks/52_netcdf.ipynb
+++ b/examples/notebooks/52_netcdf.ipynb
@@ -172,7 +172,14 @@
             "source": [
                 "m = leafmap.Map(layers_control=True)\n",
                 "m.add_basemap('CartoDB.DarkMatter')\n",
-                "m.add_velocity(filename, zonal_speed='u_wind', meridional_speed='v_wind')\n",
+                "m.add_velocity(filename,\n",
+                "               zonal_speed='u_wind',\n",
+                "               meridional_speed='v_wind',\n",
+                "               color_scale = [\"rgb(0,0,150)\",\n",
+                "                              \"rgb(0,150,0)\",\n",
+                "                              \"rgb(255,255,0)\",\n",
+                "                              \"rgb(255,165,0)\",\n",
+                "                              \"rgb(150,0,0)\"])\n",
                 "m"
             ]
         },
@@ -189,6 +196,18 @@
             "display_name": "Python 3",
             "language": "python",
             "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.8.18"
         }
     },
     "nbformat": 4,

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -3861,6 +3861,23 @@ class Map(ipyleaflet.Map):
         max_velocity=20,
         display_options={},
         name="Velocity",
+        color_scale=[
+            "rgb(36,104, 180)",
+            "rgb(60,157, 194)",
+            "rgb(128,205,193)",
+            "rgb(151,218,168)",
+            "rgb(198,231,181)",
+            "rgb(238,247,217)",
+            "rgb(255,238,159)",
+            "rgb(252,217,125)",
+            "rgb(255,182,100)",
+            "rgb(252,150,75)",
+            "rgb(250,112,52)",
+            "rgb(245,64,32)",
+            "rgb(237,45,28)",
+            "rgb(220,24,32)",
+            "rgb(180,0,35)"
+        ]
     ):
         """Add a velocity layer to the map.
 
@@ -3877,6 +3894,7 @@ class Map(ipyleaflet.Map):
             max_velocity (int, optional): The maximum velocity to display. Defaults to 20.
             display_options (dict, optional): The display options for the velocity layer. Defaults to {}. See https://bit.ly/3uf8t6w.
             name (str, optional): Layer name to use . Defaults to 'Velocity'.
+            color_scale (list, optional): List of RGB color values for the velocity vector color scale. Defaults to []. See https://bit.ly/3uf8t6w.
 
         Raises:
             ImportError: If the xarray package is not installed.
@@ -3921,6 +3939,7 @@ class Map(ipyleaflet.Map):
             max_velocity=max_velocity,
             display_options=display_options,
             name=name,
+            color_scale=color_scale,
         )
         self.add(wind)
 

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -3861,23 +3861,7 @@ class Map(ipyleaflet.Map):
         max_velocity=20,
         display_options={},
         name="Velocity",
-        color_scale=[
-            "rgb(36,104, 180)",
-            "rgb(60,157, 194)",
-            "rgb(128,205,193)",
-            "rgb(151,218,168)",
-            "rgb(198,231,181)",
-            "rgb(238,247,217)",
-            "rgb(255,238,159)",
-            "rgb(252,217,125)",
-            "rgb(255,182,100)",
-            "rgb(252,150,75)",
-            "rgb(250,112,52)",
-            "rgb(245,64,32)",
-            "rgb(237,45,28)",
-            "rgb(220,24,32)",
-            "rgb(180,0,35)"
-        ]
+        color_scale=None
     ):
         """Add a velocity layer to the map.
 
@@ -3929,6 +3913,25 @@ class Map(ipyleaflet.Map):
         if level_dimension in coords:
             ds = ds.isel(drop=True, **params)
 
+        if color_scale is None:
+            color_scale=[
+                "rgb(36,104, 180)",
+                "rgb(60,157, 194)",
+                "rgb(128,205,193)",
+                "rgb(151,218,168)",
+                "rgb(198,231,181)",
+                "rgb(238,247,217)",
+                "rgb(255,238,159)",
+                "rgb(252,217,125)",
+                "rgb(255,182,100)",
+                "rgb(252,150,75)",
+                "rgb(250,112,52)",
+                "rgb(245,64,32)",
+                "rgb(237,45,28)",
+                "rgb(220,24,32)",
+                "rgb(180,0,35)"
+            ]
+        
         wind = Velocity(
             data=ds,
             zonal_speed=zonal_speed,


### PR DESCRIPTION
This commit extends the functionality of the LeafMap module in leafmap.py, specifically focusing on the 'add_velocity' method. The primary enhancement is the introduction of the parameter, 'color_scale,' which allows users to pass a custom list of colors to be used for visualizing velocity vectors on the map.

The list was tested for RGB, HEX, and Color Names.

An example case for color_scale has been updated in the 52_netcdf.ipynb file.