### PR TITLE
87_actinia.ipynb: simplify installation of actinia_python_client

### DIFF
--- a/examples/notebooks/87_actinia.ipynb
+++ b/examples/notebooks/87_actinia.ipynb
@@ -48,17 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://github.com/actinia-org/actinia-python-client/releases/download/0.3.1/actinia_python_client-0.3.1-py3-none-any.whl'\n",
-    "leafmap.download_file(url)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install actinia_python_client-0.3.1-py3-none-any.whl"
+    "%pip install actinia_python_client"
    ]
   },
   {


### PR DESCRIPTION
Simplified installation to `pip install actinia_python_client` after recent release on https://pypi.org/project/actinia-python-client/