### PR TITLE
Fix array_to_image bug

### DIFF
--- a/docs/notebooks/89_image_array_viz.ipynb
+++ b/docs/notebooks/89_image_array_viz.ipynb
@@ -111,6 +111,92 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can also specify the image metadata (e.g., cellsize, crs, and transform) when creating the in-memory raster dataset.\n",
+    "\n",
+    "First, check the metadata of the origina image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.profile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the crs of the original image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.crs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the transform of the original image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.transform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an in-memory raster dataset from the NDVI array and specify the cellsize, crs, and transform."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform = (30.0, 0.0, -13651650.0, 0.0, -30.0, 4576290.0)\n",
+    "ndvi_image = leafmap.array_to_image(ndvi, cellsize=30, crs=\"EPSG:3857\", transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add the NDVI image to the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m.add_raster(satellite, band=[1, 2, 3], nodata=-1, layer_name=\"Landsat 7\")\n",
+    "m.add_raster(ndvi_image, cmap=\"Greens\", layer_name=\"NDVI\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Use rioxarray to read raster datasets into xarray DataArrays."
    ]
   },
@@ -193,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/89_image_array_viz.ipynb
+++ b/examples/notebooks/89_image_array_viz.ipynb
@@ -111,6 +111,92 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can also specify the image metadata (e.g., cellsize, crs, and transform) when creating the in-memory raster dataset.\n",
+    "\n",
+    "First, check the metadata of the origina image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.profile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the crs of the original image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.crs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the transform of the original image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset.transform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an in-memory raster dataset from the NDVI array and specify the cellsize, crs, and transform."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform = (30.0, 0.0, -13651650.0, 0.0, -30.0, 4576290.0)\n",
+    "ndvi_image = leafmap.array_to_image(ndvi, cellsize=30, crs=\"EPSG:3857\", transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add the NDVI image to the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m.add_raster(satellite, band=[1, 2, 3], nodata=-1, layer_name=\"Landsat 7\")\n",
+    "m.add_raster(ndvi_image, cmap=\"Greens\", layer_name=\"NDVI\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Use rioxarray to read raster datasets into xarray DataArrays."
    ]
   },
@@ -193,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix #659

Creating in-memory raster dataset from numpy array or xarray by specifying metadata such as cellsize, crs, and transform. 

```python
transform = (30.0, 0.0, -13651650.0, 0.0, -30.0, 4576290.0)
ndvi_image = leafmap.array_to_image(ndvi, cellsize=30, crs="EPSG:3857", transform=transform)
```