### PR TITLE
Remove support for JupyterLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Welcome to leafmap
 
-[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org)
 [![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/00_key_features.ipynb)
 [![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/00_key_features.ipynb&branch=master)
 [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master)
@@ -41,9 +40,8 @@ Leafmap addresses these challenges by leveraging the bidirectional communication
 
 ## Usage
 
-Launch the interactive notebook tutorial for the **leafmap** Python package with JupyterLite, Google Colab, Binder, or Amazon Sagemaker Studio Lab now:
+Launch the interactive notebook tutorial for the **leafmap** Python package with Google Colab, Binder, or Amazon Sagemaker Studio Lab now:
 
-[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org)
 [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master)
 [![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)
 [![Open In Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/00_key_features.ipynb)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 # Welcome to leafmap
 
-[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org)
 [![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/00_key_features.ipynb)
 [![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/00_key_features.ipynb&branch=master)
 [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master)
@@ -41,9 +40,8 @@ Leafmap addresses these challenges by leveraging the bidirectional communication
 
 ## Usage
 
-Launch the interactive notebook tutorial for the **leafmap** Python package with JupyterLite, Amazon SageMaker Studio Lab, Microsoft Planetary Computer, Google Colab, or Binder:
+Launch the interactive notebook tutorial for the **leafmap** Python package with Amazon SageMaker Studio Lab, Microsoft Planetary Computer, Google Colab, or Binder:
 
-[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org)
 [![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/00_key_features.ipynb)
 [![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/00_key_features.ipynb&branch=master)
 [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master)

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,6 +1,5 @@
 # Tutorials
 
-[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org)
 [![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/leafmap/blob/master/examples/notebooks/00_key_features.ipynb)
 [![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/leafmap&urlpath=lab/tree/leafmap/examples/notebooks/00_key_features.ipynb&branch=master)
 [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,8 +100,7 @@ nav:
     - Installation: installation.md
     - Get Started: get-started.md
     - Usage: notebooks/00_key_features.ipynb
-    - JupyterLite: https://demo.leafmap.org
-    - Streamlit App: https://multipage-app.streamlit.app
+    - Web App: https://huggingface.co/spaces/giswqs/solara-geospatial
     - Tutorials: tutorials.md
     - Contributing: contributing.md
     - FAQ: faq.md


### PR DESCRIPTION
Due to some upstream leafmap dependencies, it has become more and more difficult to install leafmap on JupyterLite. I am going to remove the support for JupyterLite now.

https://github.com/opengeos/leafmap/issues/565