### PR TITLE
Add xarray support for add_raster

### DIFF
--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -514,7 +514,8 @@ class Map(folium.Map):
         vmax: Optional[float] = None,
         nodata: Optional[float] = None,
         attribution: Optional[str] = None,
-        layer_name: Optional[str] = "Local COG",
+        layer_name: Optional[str] = "Raster",
+        array_args: Optional[Dict] = {},
         **kwargs,
     ):
         """Add a local raster dataset to the map.
@@ -533,8 +534,15 @@ class Map(folium.Map):
             vmax (float, optional): The maximum value to use when colormapping the colormap when plotting a single band. Defaults to None.
             nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
             attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
-            layer_name (str, optional): The layer name to use. Defaults to 'Local COG'.
+            layer_name (str, optional): The layer name to use. Defaults to 'Raster'.
+            array_args (dict, optional): Additional arguments to pass to `array_to_image`. Defaults to {}.
         """
+
+        import numpy as np
+        import xarray as xr
+
+        if isinstance(source, np.ndarray) or isinstance(source, xr.DataArray):
+            source = array_to_image(source, **array_args)
 
         tile_layer, tile_client = get_local_tile_layer(
             source,

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -2176,9 +2176,10 @@ class Map(ipyleaflet.Map):
         vmax=None,
         nodata=None,
         attribution=None,
-        layer_name="Local COG",
+        layer_name="Raster",
         zoom_to_layer=True,
         visible=True,
+        array_args={},
         **kwargs,
     ):
         """Add a local raster dataset to the map.
@@ -2197,10 +2198,17 @@ class Map(ipyleaflet.Map):
             vmax (float, optional): The maximum value to use when colormapping the palette when plotting a single band. Defaults to None.
             nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
             attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
-            layer_name (str, optional): The layer name to use. Defaults to 'Local COG'.
+            layer_name (str, optional): The layer name to use. Defaults to 'Raster'.
             zoom_to_layer (bool, optional): Whether to zoom to the extent of the layer. Defaults to True.
             visible (bool, optional): Whether the layer is visible. Defaults to True.
+            array_args (dict, optional): Additional arguments to pass to `array_to_memory_file` when reading the raster. Defaults to {}.
         """
+        import numpy as np
+        import xarray as xr
+
+        if isinstance(source, np.ndarray) or isinstance(source, xr.DataArray):
+            source = array_to_image(source, **array_args)
+
         tile_layer, tile_client = get_local_tile_layer(
             source,
             indexes=indexes,


### PR DESCRIPTION
This PR adds xarray and numpy array support for the `add_raster` method. Fix #676 @lopezvoliver

```python
m = leafmap.Map()
m.add_raster(ndvi, colormap="Greens", layer_name="NDVI", array_args={"source": satellite})
m
```