### PR TITLE
Get crs and transform from xarray rio accessor in `array_to_memory_file`

### DIFF
--- a/examples/notebooks/89_image_array_viz.ipynb
+++ b/examples/notebooks/89_image_array_viz.ipynb
@@ -231,22 +231,6 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "Create an in-memory raster dataset from the elevation class array and use the projection and extent of the DEM."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "image = leafmap.array_to_image(masked_array, source=dem)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
                 "Visualize the DEM and the elevation class image on the same map."
             ]
         },
@@ -258,7 +242,7 @@
             "source": [
                 "m = leafmap.Map()\n",
                 "m.add_raster(dem, colormap=\"terrain\", layer_name=\"DEM\")\n",
-                "m.add_raster(image, colormap=\"coolwarm\", layer_name=\"Classified DEM\")\n",
+                "m.add_raster(masked_array, colormap=\"coolwarm\", layer_name=\"Classified DEM\")\n",
                 "m"
             ]
         }

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -10293,6 +10293,15 @@ def array_to_memory_file(
             array = (
                 array.isel(time=0).rename({y_dim: "y", x_dim: "x"}).transpose("y", "x")
             )
+        if hasattr(array, "rio"):
+            if hasattr(array.rio, "crs"):
+                crs = array.rio.crs
+            if hasattr(array.rio, "transform"):
+                transform = array.rio.transform()
+        elif source is None:
+            if hasattr(array, "encoding"):
+                if "source" in array.encoding:
+                    source = array.encoding["source"]
         array = array.values
 
     if array.ndim == 3 and transpose:
@@ -10305,14 +10314,14 @@ def array_to_memory_file(
             if compress is None:
                 compress = src.compression
     else:
-        if cellsize is None:
-            raise ValueError("cellsize must be provided if source is not provided")
         if crs is None:
             raise ValueError(
                 "crs must be provided if source is not provided, such as EPSG:3857"
             )
 
         if transform is None:
+            if cellsize is None:
+                raise ValueError("cellsize must be provided if source is not provided")
             # Define the geotransformation parameters
             xmin, ymin, xmax, ymax = (
                 0,


### PR DESCRIPTION
This PR makes `array_to_memory_file` check if the array has a [rio accessor](https://corteva.github.io/rioxarray/html/rioxarray.html#rioxarray-rio-accessors), and retrieve `crs` and `transform` from it.  

This makes it possible to use `add_raster` with an xarray.DataArray without having to provide the `source` keyword argument using `array_args`. 

This is demonstrated in the updated `89_image_array_viz.ipynb` notebook:

```python
m.add_raster(masked_array, colormap="coolwarm", layer_name="Classified DEM")
```

(No need for the `image = leafmap.array_to_image(masked_array, source=dem)` step)  