### PR TITLE
Fix lonboard zoom to layer bug

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -13226,3 +13226,28 @@ def nasa_datasets(keyword=None, df=None, return_short_name=False):
             return df["ShortName"].tolist()
         else:
             return df
+
+
+def convert_coordinates(x, y, source_crs, target_crs="epsg:4326"):
+    """Convert coordinates from the source EPSG code to the target EPSG code.
+
+    Args:
+        x (float): The x-coordinate of the point.
+        y (float): The y-coordinate of the point.
+        source_crs (str): The EPSG code of the source coordinate system.
+        target_crs (str, optional): The EPSG code of the target coordinate system.
+            Defaults to '4326' (EPSG code for WGS84).
+
+    Returns:
+        tuple: A tuple containing the converted longitude and latitude.
+    """
+    import pyproj
+
+    # Create the transformer
+    transformer = pyproj.Transformer.from_crs(source_crs, target_crs, always_xy=True)
+
+    # Perform the transformation
+    lon, lat = transformer.transform(x, y)
+
+    # Return the converted coordinates
+    return lon, lat

--- a/leafmap/deckgl.py
+++ b/leafmap/deckgl.py
@@ -64,6 +64,7 @@ class Map(lonboard.Map):
         color_map: Optional[Union[str, Dict]] = None,
         color_k: Optional[int] = 5,
         color_args: dict = {},
+        zoom: Optional[float] = 10.0,
         **kwargs: Any,
     ) -> None:
         """Adds a GeoPandas GeoDataFrame to the map.
@@ -85,6 +86,7 @@ class Map(lonboard.Map):
                 'UserDefined'). Arguments can be passed in classification_kwds.
             color_k (Optional[int], optional): The number of classes to use for color encoding. Defaults to 5.
             color_args (dict, optional): Additional keyword arguments that will be passed to assign_continuous_colors(). Defaults to {}.
+            zoom (Optional[float], optional): The zoom level to zoom to. Defaults to 10.0.
             **kwargs: Additional keyword arguments that will be passed to lonboard.Layer.from_geopandas()
 
         Returns:
@@ -158,10 +160,19 @@ class Map(lonboard.Map):
         if zoom_to_layer:
             try:
                 bounds = gdf.total_bounds.tolist()
+                x = (bounds[0] + bounds[2]) / 2
+                y = (bounds[1] + bounds[3]) / 2
+
+                src_crs = gdf.crs
+                if src_crs is None:
+                    src_crs = "EPSG:4326"
+
+                lon, lat = convert_coordinates(x, y, src_crs, "EPSG:4326")
+
                 self._initial_view_state = {
-                    "latitude": (bounds[1] + bounds[3]) / 2,
-                    "longitude": (bounds[0] + bounds[2]) / 2,
-                    "zoom": 10,
+                    "latitude": lat,
+                    "longitude": lon,
+                    "zoom": zoom,
                 }
             except Exception as e:
                 print(e)


### PR DESCRIPTION
This PR fixes the bug when trying to automatically zoom to the lonboard layer. `Map._initial_view_state` only accepts EPSG:4326 coordinates. When the GeoDataFrame is not in a projection other than EPSG:4326, the map will not render. In this case, we need to convert the centroid coordinates to EPSG:4326. 