### PR TITLE
Allow to send options directly as str

### DIFF
--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -3024,8 +3024,7 @@ class Map(folium.Map):
     def add_vector_tile(
         self,
         url: Optional[str],
-        attribution: Optional[str] = "",
-        styles: Optional[dict] = {},
+        styles: Optional[Union[dict,str]] = {},
         layer_name: Optional[str] = "Vector Tile",
         **kwargs,
     ):
@@ -3036,22 +3035,26 @@ class Map(folium.Map):
             url (str, optional): The URL of the tile layer, such as
                 'https://tile.nextzen.org/tilezen/vector/v1/512/all/{z}/{x}/{y}.mvt?api_key=gCZXZglvRQa6sB2z7JzL1w'.
             attribution (str, optional): The attribution to use. Defaults to ''.
-            styles (dict,optional): Style dict, specific to the vector tile source.
+            styles (dict | str, optional): Style dict, specific to the vector tile source.
+                If styles is given as a string, it will be passed directly to folium.plugins.VectorGrid
+                directly, ignoring additional kwargs. See the "conditional styling" example in
+                https://github.com/iwpnd/folium-vectorgrid
             layer_name (str, optional): The layer name to use for the layer. Defaults to 'Vector Tile'.
-            kwargs: Additional keyword arguments to pass to the ipyleaflet.VectorTileLayer class.
+            kwargs: Additional keyword arguments to pass to the folium.plugins.VectorGridProtobuf class.
         """
+        if isinstance(styles, str):
+            options = styles
+        else:
+            options = {}
+            for key, value in kwargs.items():
+                options[key] = value
 
-        options = {}
+            if "vector_tile_layer_styles" in options:
+                styles = options["vector_tile_layer_styles"]
+                del options["vector_tile_layer_styles"]
 
-        for key, value in kwargs.items():
-            options[key] = value
-
-        if "vector_tile_layer_styles" in options:
-            styles = options["vector_tile_layer_styles"]
-            del options["vector_tile_layer_styles"]
-
-        if styles:
-            options["vectorTileLayerStyles"] = styles
+            if styles:
+                options["vectorTileLayerStyles"] = styles
 
         vc = plugins.VectorGridProtobuf(url, layer_name, options)
         self.add_child(vc)

--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -3024,7 +3024,7 @@ class Map(folium.Map):
     def add_vector_tile(
         self,
         url: Optional[str],
-        styles: Optional[Union[dict,str]] = {},
+        styles: Optional[Union[dict, str]] = {},
         layer_name: Optional[str] = "Vector Tile",
         **kwargs,
     ):


### PR DESCRIPTION
Adds the possibility to send `options` for the `folium.plugins.VectorGridProtobuf` directly as a string, so that a JS function may be used for conditional styling (e.g., see the [second example here](https://github.com/iwpnd/folium-vectorgrid))

Here's an example with the normal `styles`:

![image](https://github.com/opengeos/leafmap/assets/14804652/31e33f11-7d1b-4647-b2c0-61070106b150)

Here's an example with conditional styling:

![image](https://github.com/opengeos/leafmap/assets/14804652/9e3a8ac1-f73c-4fb1-a1d8-44cfc4208eb6)

where `options` was defined as a string as follows:

options='''{
  "vectorTileLayerStyles": {
    "myLayer": function(f) {
      var color = "#86340c"; 
      if (f.ET >= 250) {
        color = "#c49e0d";
      }
      if (f.ET >= 500) {
        color = "#f3fe34";
      }
      if (f.ET >= 750) {
        color = "#aefeae";
      }
      if (f.ET >= 1000) {
        color = "#11f9fd";
      }
      if (f.ET >= 1250) {
        color = "#698afc";
      }
      if (f.ET >= 1500) {
        color = "#5813fc";
      }
      return {
        fillOpacity: 1,
        fillColor: color,
        fill: true,
        weight: 1,
        color: "white",
        opacity: 1,
      };
    }
  }    
}'''


- Also removed `attribution` since it is not being used.
- Also rearranged the order to match the one by `VectorGridProtobuf` ( url, layer_name, options/styles)