### PR TITLE
Add tile layer params for split map

### DIFF
--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -2614,6 +2614,7 @@ class Map(folium.Map):
                         name=left_name,
                         attr=" ",
                         overlay=True,
+                        **left_args,
                     )
 
                 elif left_layer.startswith("http") and left_layer.endswith(".json"):
@@ -2625,6 +2626,7 @@ class Map(folium.Map):
                         name=left_name,
                         attr=" ",
                         overlay=True,
+                        **left_args,
                     )
 
                 elif os.path.exists(left_layer):
@@ -2673,6 +2675,7 @@ class Map(folium.Map):
                         name=right_name,
                         attr=" ",
                         overlay=True,
+                        **right_args,
                     )
 
                 elif right_layer.startswith("http") and right_layer.endswith(".json"):
@@ -2684,6 +2687,7 @@ class Map(folium.Map):
                         name=right_name,
                         attr=" ",
                         overlay=True,
+                        **right_args,
                     )
 
                 elif os.path.exists(right_layer):

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -1471,6 +1471,7 @@ class Map(ipyleaflet.Map):
                         url=url,
                         name=left_name,
                         attribution=" ",
+                        **left_args,
                     )
                 elif left_layer.startswith("http") and left_layer.endswith(".json"):
                     left_tile_url = stac_tile(left_layer, **left_args)
@@ -1480,6 +1481,7 @@ class Map(ipyleaflet.Map):
                         url=left_tile_url,
                         name=left_name,
                         attribution=" ",
+                        **left_args,
                     )
                 elif left_layer.startswith("http") and left_layer.endswith(".geojson"):
                     if "max_zoom" in left_args:
@@ -1539,6 +1541,7 @@ class Map(ipyleaflet.Map):
                         url=url,
                         name=right_name,
                         attribution=" ",
+                        **right_args,
                     )
 
                 elif right_layer.startswith("http") and right_layer.endswith(".json"):
@@ -1549,6 +1552,7 @@ class Map(ipyleaflet.Map):
                         url=right_tile_url,
                         name=right_name,
                         attribution=" ",
+                        **right_args,
                     )
                 elif right_layer.startswith("http") and right_layer.endswith(
                     ".geojson"


### PR DESCRIPTION
This PR adds tile layer params to the split map so that it can supports params such as `opacity`

```python
import leafmap

url = "https://open.gishub.org/data/raster/srtm90.tif"

m = leafmap.Map(center=[37.6, -119], zoom=9)
m.split_map(
    url,
    url,
    left_args={"layer_name": "DEM", "colormap_name": "terrain", "opacity": 0.7},
    right_args={"layer_name": "Classified DEM", "colormap_name": "coolwarm", "opacity": 0.5}
)
m
```

![image](https://github.com/opengeos/leafmap/assets/5016453/9e474d87-2012-48e2-93e0-6e9af3d8dd09)


