### PR TITLE
Fix pydeck basemap issue

### DIFF
--- a/leafmap/deck.py
+++ b/leafmap/deck.py
@@ -91,10 +91,11 @@ class Map(pdk.Deck):
                 self.add_layer(url, name)
 
             elif basemap in basemaps:
+                # Use pydeck_myTileLayer from https://github.com/agressin/pydeck_myTileLayer
                 pdk.settings.custom_libraries = [
                     {
                         "libraryName": "MyTileLayerLibrary",
-                        "resourceUri": "https://cdn.jsdelivr.net/gh/giswqs/pydeck_myTileLayer@master/dist/bundle.js",
+                        "resourceUri": "https://cdn.jsdelivr.net/gh/agressin/pydeck_myTileLayer@master/dist/bundle.js",
                     }
                 ]
 


### PR DESCRIPTION
This PR fixes the pydeck basemap issue reported in https://github.com/opengeos/leafmap/issues/753. Somehow the pydeck_myTileLayer resourceUri stopped working. Updating the URL solves the issue. 

https://github.com/agressin/pydeck_myTileLayer

![image](https://github.com/opengeos/leafmap/assets/5016453/bc5ca802-f238-4713-ab42-39848d03c73d)
