### PR TITLE
Improve add_vector for the deck module

### DIFF
--- a/docs/notebooks/29_pydeck.ipynb
+++ b/docs/notebooks/29_pydeck.ipynb
@@ -69,7 +69,7 @@
    "outputs": [],
    "source": [
     "m = leafmap.Map()\n",
-    "m.add_basemap(\"HYBRID\")\n",
+    "m.add_basemap(\"OpenTopoMap\")\n",
     "m"
    ]
   },
@@ -181,6 +181,61 @@
    "metadata": {},
    "source": [
     "![](https://i.imgur.com/LbCKhcM.gif)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=(40, -100), zoom=3)\n",
+    "DATA_URL = \"https://data.source.coop/cboettig/conservation-policy/Inflation_Reduction_Act_Projects.geojson\"\n",
+    "gdf = gpd.read_file(DATA_URL)\n",
+    "\n",
+    "m.add_vector(\n",
+    "    gdf,\n",
+    "    layer_type=\"ColumnLayer\",\n",
+    "    get_position=[\"LONGITUDE\", \"LATITUDE\"],\n",
+    "    get_elevation=\"FUNDING_NUMERIC\",\n",
+    "    get_fill_color=[256, 256, 0, 140],\n",
+    "    elevation_scale=0.01,\n",
+    "    radius=10000,\n",
+    "    pickable=True,\n",
+    "    auto_highlight=True,\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pydeck as pdk\n",
+    "\n",
+    "m = leafmap.Map(center=(40, -100), zoom=3)\n",
+    "\n",
+    "DATA_URL = \"https://data.source.coop/cboettig/conservation-policy/Inflation_Reduction_Act_Projects.geojson\"\n",
+    "df = gpd.read_file(DATA_URL)\n",
+    "\n",
+    "column_layer = pdk.Layer(\n",
+    "    \"ColumnLayer\",\n",
+    "    data=df,\n",
+    "    get_position=[\"LONGITUDE\", \"LATITUDE\"],\n",
+    "    get_elevation=\"FUNDING_NUMERIC\",\n",
+    "    get_fill_color=[256, 256, 0, 140],\n",
+    "    elevation_scale=0.01,\n",
+    "    radius=10000,\n",
+    "    pickable=True,\n",
+    "    auto_highlight=True,\n",
+    ")\n",
+    "\n",
+    "m.add_layer(column_layer)\n",
+    "m"
    ]
   }
  ],

--- a/examples/notebooks/29_pydeck.ipynb
+++ b/examples/notebooks/29_pydeck.ipynb
@@ -69,7 +69,7 @@
    "outputs": [],
    "source": [
     "m = leafmap.Map()\n",
-    "m.add_basemap(\"HYBRID\")\n",
+    "m.add_basemap(\"OpenTopoMap\")\n",
     "m"
    ]
   },
@@ -181,6 +181,61 @@
    "metadata": {},
    "source": [
     "![](https://i.imgur.com/LbCKhcM.gif)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=(40, -100), zoom=3)\n",
+    "DATA_URL = \"https://data.source.coop/cboettig/conservation-policy/Inflation_Reduction_Act_Projects.geojson\"\n",
+    "gdf = gpd.read_file(DATA_URL)\n",
+    "\n",
+    "m.add_vector(\n",
+    "    gdf,\n",
+    "    layer_type=\"ColumnLayer\",\n",
+    "    get_position=[\"LONGITUDE\", \"LATITUDE\"],\n",
+    "    get_elevation=\"FUNDING_NUMERIC\",\n",
+    "    get_fill_color=[256, 256, 0, 140],\n",
+    "    elevation_scale=0.01,\n",
+    "    radius=10000,\n",
+    "    pickable=True,\n",
+    "    auto_highlight=True,\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pydeck as pdk\n",
+    "\n",
+    "m = leafmap.Map(center=(40, -100), zoom=3)\n",
+    "\n",
+    "DATA_URL = \"https://data.source.coop/cboettig/conservation-policy/Inflation_Reduction_Act_Projects.geojson\"\n",
+    "df = gpd.read_file(DATA_URL)\n",
+    "\n",
+    "column_layer = pdk.Layer(\n",
+    "    \"ColumnLayer\",\n",
+    "    data=df,\n",
+    "    get_position=[\"LONGITUDE\", \"LATITUDE\"],\n",
+    "    get_elevation=\"FUNDING_NUMERIC\",\n",
+    "    get_fill_color=[256, 256, 0, 140],\n",
+    "    elevation_scale=0.01,\n",
+    "    radius=10000,\n",
+    "    pickable=True,\n",
+    "    auto_highlight=True,\n",
+    ")\n",
+    "\n",
+    "m.add_layer(column_layer)\n",
+    "m"
    ]
   }
  ],

--- a/leafmap/deck.py
+++ b/leafmap/deck.py
@@ -193,6 +193,7 @@ class Map(pdk.Deck):
     def add_vector(
         self,
         data: str,
+        layer_type: str = "GeoJsonLayer",
         layer_name: Optional[str] = None,
         random_color_column: Optional[str] = None,
         **kwargs
@@ -201,6 +202,7 @@ class Map(pdk.Deck):
 
         Args:
             data (str): The input file path to the vector dataset.
+            layer_type (str, optional): The layer type to be used. Defaults to "GeoJsonLayer".
             layer_name (str, optional): The layer name to be used. Defaults to None.
             random_color_column (str, optional): The column name to use for random color. Defaults to None.
 
@@ -226,7 +228,7 @@ class Map(pdk.Deck):
             else:
                 gdf = data
 
-            self.add_gdf(gdf, layer_name, random_color_column, **kwargs)
+            self.add_gdf(gdf, layer_type, layer_name, random_color_column, **kwargs)
 
         except Exception as e:
             raise Exception(e)

--- a/leafmap/deck.py
+++ b/leafmap/deck.py
@@ -120,6 +120,7 @@ class Map(pdk.Deck):
     def add_gdf(
         self,
         gdf,
+        layer_type="GeoJsonLayer",
         layer_name: Optional[str] = None,
         random_color_column: Optional[str] = None,
         **kwargs
@@ -128,6 +129,7 @@ class Map(pdk.Deck):
 
         Args:
             gdf (GeoPandas.GeoDataFrame): The GeoPandas GeoDataFrame to add to the map.
+            layer_type (str, optional): The layer type to be used. Defaults to "GeoJsonLayer".
             layer_name (str, optional): The layer name to be used. Defaults to None.
             random_color_column (str, optional): The column name to use for random color. Defaults to None.
 
@@ -144,24 +146,25 @@ class Map(pdk.Deck):
             if layer_name is None:
                 layer_name = "layer_" + random_string(3)
 
-            if "pickable" not in kwargs:
-                kwargs["pickable"] = True
-            if "opacity" not in kwargs:
-                kwargs["opacity"] = 0.5
-            if "stroked" not in kwargs:
-                kwargs["stroked"] = True
-            if "filled" not in kwargs:
-                kwargs["filled"] = True
-            if "extruded" not in kwargs:
-                kwargs["extruded"] = False
-            if "wireframe" not in kwargs:
-                kwargs["wireframe"] = True
-            if "get_line_color" not in kwargs:
-                kwargs["get_line_color"] = [0, 0, 0]
-            if "get_line_width" not in kwargs:
-                kwargs["get_line_width"] = 2
-            if "line_width_min_pixels" not in kwargs:
-                kwargs["line_width_min_pixels"] = 1
+            if "layer_type" == "GeoJsonLayer":
+                if "pickable" not in kwargs:
+                    kwargs["pickable"] = True
+                if "opacity" not in kwargs:
+                    kwargs["opacity"] = 0.5
+                if "stroked" not in kwargs:
+                    kwargs["stroked"] = True
+                if "filled" not in kwargs:
+                    kwargs["filled"] = True
+                if "extruded" not in kwargs:
+                    kwargs["extruded"] = False
+                if "wireframe" not in kwargs:
+                    kwargs["wireframe"] = True
+                if "get_line_color" not in kwargs:
+                    kwargs["get_line_color"] = [0, 0, 0]
+                if "get_line_width" not in kwargs:
+                    kwargs["get_line_width"] = 2
+                if "line_width_min_pixels" not in kwargs:
+                    kwargs["line_width_min_pixels"] = 1
 
             if random_color_column is not None:
                 if random_color_column not in gdf.columns.values.tolist():
@@ -177,7 +180,7 @@ class Map(pdk.Deck):
                 kwargs["get_fill_color"] = "color"
 
             layer = pdk.Layer(
-                "GeoJsonLayer",
+                layer_type,
                 gdf,
                 id=layer_name,
                 **kwargs,
@@ -189,7 +192,7 @@ class Map(pdk.Deck):
 
     def add_vector(
         self,
-        filename: str,
+        data: str,
         layer_name: Optional[str] = None,
         random_color_column: Optional[str] = None,
         **kwargs
@@ -197,7 +200,7 @@ class Map(pdk.Deck):
         """Adds a vector file to the map.
 
         Args:
-            filename (str): The input file path to the vector dataset.
+            data (str): The input file path to the vector dataset.
             layer_name (str, optional): The layer name to be used. Defaults to None.
             random_color_column (str, optional): The column name to use for random color. Defaults to None.
 
@@ -209,16 +212,19 @@ class Map(pdk.Deck):
             import geopandas as gpd
             import fiona
 
-            if not filename.startswith("http"):
-                filename = os.path.abspath(filename)
-                if filename.endswith(".zip"):
-                    filename = "zip://" + filename
+            if isinstance(data, str):
+                if not data.startswith("http"):
+                    data = os.path.abspath(data)
+                    if data.endswith(".zip"):
+                        data = "zip://" + data
 
-            if filename.endswith(".kml"):
-                fiona.drvsupport.supported_drivers["KML"] = "rw"
-                gdf = gpd.read_file(filename, driver="KML")
+                if data.endswith(".kml"):
+                    fiona.drvsupport.supported_drivers["KML"] = "rw"
+                    gdf = gpd.read_file(data, driver="KML")
+                else:
+                    gdf = gpd.read_file(data)
             else:
-                gdf = gpd.read_file(filename)
+                gdf = data
 
             self.add_gdf(gdf, layer_name, random_color_column, **kwargs)
 


### PR DESCRIPTION
This PR fixes the issue reported in #754.  @cboettig

By default, the `Map.add_vector()` function uses the `GeoJsonLayer` layer type, but it can be changed to other layer types, such as `ColumnLayer`. Users can also construct a `pydeck.Layer` object and then use `Map.add_layer()` to add it to the map. 

```python
import leafmap.deck as leafmap
import geopandas as gpd

m = leafmap.Map(center=(40, -100), zoom=3)
DATA_URL = 'https://data.source.coop/cboettig/conservation-policy/Inflation_Reduction_Act_Projects.geojson'
gdf = gpd.read_file(DATA_URL)

m.add_vector(gdf,layer_type="ColumnLayer", get_position=["LONGITUDE", "LATITUDE"], get_elevation="FUNDING_NUMERIC",
    get_fill_color = [256,256,0, 140],
    elevation_scale=.01,
    radius=10000,
    pickable=True,
    auto_highlight=True,)
m
```

```python
import leafmap.deck as leafmap
import geopandas as gpd
import pydeck as pdk

m = leafmap.Map(center=(40, -100), zoom=3)

DATA_URL = 'https://data.source.coop/cboettig/conservation-policy/Inflation_Reduction_Act_Projects.geojson'
df = gpd.read_file(DATA_URL)

column_layer = pdk.Layer(
    "ColumnLayer",
    data=df,
    get_position=["LONGITUDE", "LATITUDE"],
    get_elevation="FUNDING_NUMERIC",
    get_fill_color = [256,256,0, 140],
    elevation_scale=.01,
    radius=10000,
    pickable=True,
    auto_highlight=True,
)

m.add_layer(column_layer)
m
```

![image](https://github.com/opengeos/leafmap/assets/5016453/988ba6be-dc8b-4469-99ec-7b6d9188f43e)
