### PR TITLE
Add more MapLibre examples

### DIFF
--- a/docs/maplibre/add_image.ipynb
+++ b/docs/maplibre/add_image.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=maplibre/add_image.ipynb)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/docs/maplibre/add_image.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)\n",
+    "\n",
+    "**Add an icon to the map**\n",
+    "\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add an icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/add-image).\n",
+    "\n",
+    "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"leafmap[maplibre]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import leafmap.maplibregl as leafmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run this notebook, you will need an [API key](https://docs.maptiler.com/cloud/api/authentication-key/) from [MapTiler](https://www.maptiler.com/cloud/). Once you have the API key, you can set it as an environment variable in your notebook or script as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# os.environ[\"MAPTILER_KEY\"] = \"YOUR_API_KEY\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAPTILER_KEY = os.environ.get(\"MAPTILER_KEY\")\n",
+    "style = f\"https://api.maptiler.com/maps/streets/style.json?key={MAPTILER_KEY}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[-1.80921, 0.349419], zoom=3, style=style)\n",
+    "image = 'https://upload.wikimedia.org/wikipedia/commons/7/7c/201408_cat.png'\n",
+    "source = {\n",
+    "    'type': 'geojson',\n",
+    "    'data': {\n",
+    "        'type': 'FeatureCollection',\n",
+    "        'features': [\n",
+    "            {'type': 'Feature', 'geometry': {'type': 'Point', 'coordinates': [0, 0]}}\n",
+    "        ],\n",
+    "    },\n",
+    "}\n",
+    "layer = {\n",
+    "    'id': 'points',\n",
+    "    'type': 'symbol',\n",
+    "    'source': 'point',\n",
+    "    'layout': {'icon-image': 'cat', 'icon-size': 0.25},\n",
+    "}\n",
+    "m.add_image(\"cat\", image)\n",
+    "m.add_source('point', source)\n",
+    "m.add_layer(layer)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/oDoxdQ0.png)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/maplibre/deckgl_layer.ipynb
+++ b/docs/maplibre/deckgl_layer.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=maplibre/deckgl_layer.ipynb)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/docs/maplibre/deckgl_layer.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)\n",
+    "\n",
+    "**Add deck.gl layers**\n",
+    "\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Create deck.gl layer using REST API](https://maplibre.org/maplibre-gl-js/docs/examples/add-deckgl-layer-using-rest-api).\n",
+    "\n",
+    "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"leafmap[maplibre]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import leafmap.maplibregl as leafmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(\n",
+    "    style=\"positron\",\n",
+    "    center=(37.74, -122.4),\n",
+    "    zoom=12,\n",
+    "    pitch=40,\n",
+    ")\n",
+    "deck_grid_layer = {\n",
+    "    \"@@type\": \"GridLayer\",\n",
+    "    \"id\": \"GridLayer\",\n",
+    "    \"data\": \"https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/sf-bike-parking.json\",\n",
+    "    \"extruded\": True,\n",
+    "    \"getPosition\": \"@@=COORDINATES\",\n",
+    "    \"getColorWeight\": \"@@=SPACES\",\n",
+    "    \"getElevationWeight\": \"@@=SPACES\",\n",
+    "    \"elevationScale\": 4,\n",
+    "    \"cellSize\": 200,\n",
+    "    \"pickable\": True,\n",
+    "}\n",
+    "\n",
+    "m.add_deck_layers([deck_grid_layer], tooltip=\"Number of points: {{ count }}\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/rQR4687.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(\n",
+    "    style=\"positron\",\n",
+    "    center=(49.254, -123.13),\n",
+    "    zoom=11,\n",
+    "    pitch=45,\n",
+    ")\n",
+    "deck_grid_layer = {\n",
+    "    \"@@type\": \"GeoJsonLayer\",\n",
+    "    \"id\": \"GeoJsonLayer\",\n",
+    "    \"data\": \"https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/geojson/vancouver-blocks.json\",\n",
+    "    \"opacity\": 0.8,\n",
+    "    \"stroked\": False,\n",
+    "    \"filled\": True,\n",
+    "    \"extruded\": True,\n",
+    "    \"wireframe\": True,\n",
+    "    \"getElevation\": \"@@=properties.valuePerSqm / 20\",\n",
+    "    \"getFillColor\": [255, 255, \"@@=properties.growth * 255\"],\n",
+    "    \"getLineColor\": [255, 255, 255],\n",
+    "}\n",
+    "m.add_deck_layers([deck_grid_layer])\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/rcO5RAD.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = requests.get(\n",
+    "    \"https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_10m_airports.geojson\"\n",
+    ").json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(\n",
+    "    style=\"positron\",\n",
+    "    center=(51.47, 0.45),\n",
+    "    zoom=4,\n",
+    "    pitch=30,\n",
+    ")\n",
+    "deck_geojson_layer = {\n",
+    "    \"@@type\": \"GeoJsonLayer\",\n",
+    "    \"id\": \"airports\",\n",
+    "    \"data\": data,\n",
+    "    \"filled\": True,\n",
+    "    \"pointRadiusMinPixels\": 2,\n",
+    "    \"pointRadiusScale\": 2000,\n",
+    "    \"getPointRadius\": \"@@=11 - properties.scalerank\",\n",
+    "    \"getFillColor\": [200, 0, 80, 180],\n",
+    "    \"autoHighlight\": True,\n",
+    "    \"pickable\": True,\n",
+    "}\n",
+    "\n",
+    "deck_arc_layer = {\n",
+    "    \"@@type\": \"ArcLayer\",\n",
+    "    \"id\": \"arcs\",\n",
+    "    \"data\": [\n",
+    "        feature\n",
+    "        for feature in data[\"features\"]\n",
+    "        if feature[\"properties\"][\"scalerank\"] < 4\n",
+    "    ],\n",
+    "    \"getSourcePosition\": [-0.4531566, 51.4709959],  # London\n",
+    "    \"getTargetPosition\": \"@@=geometry.coordinates\",\n",
+    "    \"getSourceColor\": [0, 128, 200],\n",
+    "    \"getTargetColor\": [200, 0, 80],\n",
+    "    \"getWidth\": 2,\n",
+    "    \"pickable\": True,\n",
+    "}\n",
+    "\n",
+    "m.add_deck_layers(\n",
+    "    [deck_geojson_layer, deck_arc_layer],\n",
+    "    tooltip={\n",
+    "        \"airports\": \"{{ &properties.name }}\",\n",
+    "        \"arcs\": \"gps_code: {{ properties.gps_code }}\",\n",
+    "    },\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/mO1Z1Kz.png)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/maplibre/overview.md
+++ b/docs/maplibre/overview.md
@@ -26,6 +26,18 @@ Add a default marker to the map.
 
 [![](https://i.imgur.com/ufmqTzx.png)](https://leafmap.org/maplibre/add_marker)
 
+## Add deck.gl layers
+
+Add deck.gl layers to the map.
+
+[![](https://i.imgur.com/rQR4687.png)](https://leafmap.org/maplibre/deckgl_layers)
+
+## Add an icon to the map
+
+Add an icon to the map from an external URL and use it in a symbol layer.
+
+[![](https://i.imgur.com/oDoxdQ0.png)](https://leafmap.org/maplibre/add_image)
+
 ## Add a video
 
 Display a video on top of a satellite raster baselayer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,8 @@ nav:
           - maplibre/3d_indoor_mapping.ipynb
           - maplibre/3d_terrain.ipynb
           - maplibre/add_marker.ipynb
+          - maplibre/deckgl_layers.ipynb
+          - maplibre/add_image.ipynb
           - maplibre/fit_bounds.ipynb
           - maplibre/fly_to.ipynb
           - maplibre/fly_to_options.ipynb


### PR DESCRIPTION
This PR adds more MapLibre examples and the `add_image()` method. 

## Add deck.gl layers

Add deck.gl layers to the map.

[![](https://i.imgur.com/rQR4687.png)](https://leafmap.org/maplibre/deckgl_layers)

## Add an icon to the map

Add an icon to the map from an external URL and use it in a symbol layer.

[![](https://i.imgur.com/oDoxdQ0.png)](https://leafmap.org/maplibre/add_image)