### PR TITLE
Improve MapLibre to_html function

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -13951,3 +13951,28 @@ def github_upload_asset_to_release(
         if not quiet:
             print(response.json())
         return None
+
+
+def remove_port_from_string(data: str) -> str:
+    """
+    Removes the port number from all URLs in the given string.
+
+    Args::
+        data (str): The input string containing URLs.
+
+    Returns:
+        str: The string with port numbers removed from all URLs.
+    """
+    import re
+
+    # Regular expression to match URLs with port numbers
+    url_with_port_pattern = re.compile(r"(http://[\d\w.]+):\d+")
+
+    # Function to remove the port from the matched URLs
+    def remove_port(match):
+        return match.group(1)
+
+    # Substitute the URLs with ports removed
+    result = url_with_port_pattern.sub(remove_port, data)
+
+    return result

--- a/leafmap/maplibregl.py
+++ b/leafmap/maplibregl.py
@@ -572,7 +572,7 @@ class Map(MapWidget):
             raise ValueError("The data must be a URL or a GeoJSON dictionary.")
 
         if name is None:
-            name = "geojson_" + random_string()
+            name = "geojson"
 
         if filter is not None:
             kwargs["filter"] = filter
@@ -1177,6 +1177,7 @@ class Map(MapWidget):
         width: str = "100%",
         height: str = "100%",
         replace_key: bool = False,
+        remove_port: bool = True,
         preview: bool = False,
         overwrite: bool = False,
         **kwargs,
@@ -1194,6 +1195,7 @@ class Map(MapWidget):
                 The API key is read from the environment variable `MAPTILER_KEY`.
                 The public API key is read from the environment variable `MAPTILER_KEY_PUBLIC`.
                 Defaults to False.
+            remove_port (bool, optional): Whether to remove the port number from the HTML.
             preview (bool, optional): Whether to preview the HTML file in a web browser.
                 Defaults to False.
             overwrite (bool, optional): Whether to overwrite the output file if it already exists.
@@ -1236,7 +1238,11 @@ class Map(MapWidget):
             if key_after is not None:
                 html = html.replace(key_before, key_after)
 
-        output = os.getenv("MAPLIBRE_OUTPUT", None)
+        if remove_port:
+            html = remove_port_from_string(html)
+
+        if output is None:
+            output = os.getenv("MAPLIBRE_OUTPUT", None)
 
         if output:
 


### PR DESCRIPTION
Remove the random port number in the HTML generated from the `add_raster()` function to avoid being identified as changes by Git. 