### PR TITLE
Updated the init of the foliumap.Map and improved the imports

### DIFF
--- a/tests/test_foliumap.py
+++ b/tests/test_foliumap.py
@@ -6,8 +6,7 @@ import os
 import unittest
 import leafmap.foliumap as leafmap
 import geopandas as gpd
-import pandas as pd
-from unittest.mock import patch
+from ..leafmap.common import set_api_key
 
 
 class TestFoliumap(unittest.TestCase):
@@ -22,7 +21,7 @@ class TestFoliumap(unittest.TestCase):
     def test_add_basemap(self):
         """Check basemaps"""
         m = leafmap.Map()
-        leafmap.set_api_key("API-KEY")
+        set_api_key("API-KEY")
         m.add_basemap("TERRAIN")
         out_str = m.to_html()
         assert "Google Terrain" in out_str


### PR DESCRIPTION
Hey,
I love using foliumap. One thing I miss though is some typehints for the init. This PR improves the init method of the foliumap.Map.

The tests still work, and also with some manual testing everything works as before. The perk of this update is that initializing a map in an IDE is somewhat more documented:

![image](https://github.com/opengeos/leafmap/assets/73856313/5fb274dd-215f-4301-bc24-0e799f9175f6)

If you agree with this update, I could do some more reworks throughout the code in the coming weeks. If not, no hard feelings :)

PS. I also did a small code quality update in foliumap.py while working in it. I reworked the imports, with as main goal avoiding * imports.