### PR TITLE
Pin matplotlib==3.9.0 for Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,6 +66,7 @@ jobs:
 
             - name: Install dependencies
               run: |
+                  pip install matplotlib==3.9.0
                   pip install -r requirements.txt
                   pip install .
                   pip install pytest
@@ -78,4 +79,4 @@ jobs:
 
             - name: Testing with pytest
               run: |
-                 pytest . --verbose
+                  pytest . --verbose


### PR DESCRIPTION
There is bug with matplotlib 3.9.1 on Windows. We need to pin matplotlib==3.9.0 temporarily to fix the issue. 