### PR TITLE
Remove matplotlib version pin

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,6 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  pip install matplotlib==3.9.0
                   pip install -r requirements.txt
                   pip install .
                   pip install pytest


### PR DESCRIPTION
The matplotlib issue has been fixed upstream. We can remove the version pin now. 