### PR TITLE
Fix COG custom colormap bug

### DIFF
--- a/docs/notebooks/03_cog_stac.ipynb
+++ b/docs/notebooks/03_cog_stac.ipynb
@@ -225,6 +225,45 @@
   },
   {
    "cell_type": "markdown",
+   "id": "36ae1531",
+   "metadata": {},
+   "source": [
+    "Use custom colormap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "677c1cf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://clarkcga-aquaculture.s3.amazonaws.com/data/el_salvador/cover/El_Salvador_Landcover_2022.tif\"\n",
+    "custom_cmap = {\n",
+    "    \"0\": \"#000000\",\n",
+    "    \"1\": \"#008040\",\n",
+    "    \"2\": \"#ff0000\",\n",
+    "    \"3\": \"#ffff00\",\n",
+    "    \"4\": \"#8000ff\",\n",
+    "    \"5\": \"#8080ff\",\n",
+    "    \"6\": \"#00ff00\",\n",
+    "    \"7\": \"#c0c0c0\",\n",
+    "    \"8\": \"#16002d\",\n",
+    "    \"9\": \"#ff80ff\",\n",
+    "    \"10\": \"#b3ffb3\",\n",
+    "    \"11\": \"#ff8080\",\n",
+    "    \"12\": \"#ffffbf\",\n",
+    "    \"13\": \"#000080\",\n",
+    "    \"14\": \"#808000\",\n",
+    "    \"15\": \"#00ffff\",\n",
+    "}\n",
+    "m = leafmap.Map()\n",
+    "m.add_cog_layer(url, colormap=custom_cmap, name=\"El_Salvador\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "22",
    "metadata": {},
    "source": [

--- a/docs/notebooks/03_cog_stac.ipynb
+++ b/docs/notebooks/03_cog_stac.ipynb
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36ae1531",
+   "id": "22",
    "metadata": {},
    "source": [
     "Use custom colormap."
@@ -234,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "677c1cf8",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "source": [
     "**Working with  SpatioTemporal Asset Catalog (STAC)**\n",
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "source": [
     "Create an interactive map."
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,28 +308,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
-   "metadata": {},
-   "source": [
-    "Retrieve the bounding box coordinates of the STAC file."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "leafmap.stac_bounds(url)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "28",
    "metadata": {},
    "source": [
-    "Retrieve the centroid coordinates of the STAC file."
+    "Retrieve the bounding box coordinates of the STAC file."
    ]
   },
   {
@@ -339,7 +321,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "leafmap.stac_center(url)"
+    "leafmap.stac_bounds(url)"
    ]
   },
   {
@@ -347,7 +329,7 @@
    "id": "30",
    "metadata": {},
    "source": [
-    "Retrieve the band names of the STAC file."
+    "Retrieve the centroid coordinates of the STAC file."
    ]
   },
   {
@@ -357,7 +339,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "leafmap.stac_bands(url)"
+    "leafmap.stac_center(url)"
    ]
   },
   {
@@ -365,7 +347,7 @@
    "id": "32",
    "metadata": {},
    "source": [
-    "Retrieve the tile layer URL of the STAC file."
+    "Retrieve the band names of the STAC file."
    ]
   },
   {
@@ -375,7 +357,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "leafmap.stac_tile(url, bands=[\"B3\", \"B2\", \"B1\"])"
+    "leafmap.stac_bands(url)"
    ]
   },
   {
@@ -383,7 +365,7 @@
    "id": "34",
    "metadata": {},
    "source": [
-    "Add a STAC layer to the map."
+    "Retrieve the tile layer URL of the STAC file."
    ]
   },
   {
@@ -393,13 +375,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "leafmap.stac_tile(url, bands=[\"B3\", \"B2\", \"B1\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36",
+   "metadata": {},
+   "source": [
+    "Add a STAC layer to the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "Map.add_stac_layer(url, bands=[\"pan\"], name=\"Panchromatic\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/leafmap/stac.py
+++ b/leafmap/stac.py
@@ -146,6 +146,7 @@ def cog_tile(
     Returns:
         tuple: Returns the COG Tile layer URL and bounds.
     """
+    import json
 
     titiler_endpoint = check_titiler_endpoint(titiler_endpoint)
 
@@ -180,7 +181,7 @@ def cog_tile(
     elif isinstance(kwargs["bidx"], int):
         kwargs["bidx"] = [kwargs["bidx"]]
 
-    if "rescale" not in kwargs:
+    if "rescale" not in kwargs and ("colormap" not in kwargs):
         stats = cog_stats(url, titiler_endpoint)
 
         if "message" not in stats:
@@ -196,6 +197,9 @@ def cog_tile(
                 kwargs["rescale"] = rescale
             except Exception as e:
                 pass
+
+    if "colormap" in kwargs and isinstance(kwargs["colormap"], dict):
+        kwargs["colormap"] = json.dumps(kwargs["colormap"])
 
     TileMatrixSetId = "WebMercatorQuad"
     if "TileMatrixSetId" in kwargs.keys():


### PR DESCRIPTION
Fix #867 

```python
import leafmap

url = "https://clarkcga-aquaculture.s3.amazonaws.com/data/el_salvador/cover/El_Salvador_Landcover_2022.tif"
custom_cmap = {
    "0": "#000000",
    "1": "#008040",
    "2": "#ff0000",
    "3": "#ffff00",
    "4": "#8000ff",
    "5": "#8080ff",
    "6": "#00ff00",
    "7": "#c0c0c0",
    "8": "#16002d",
    "9": "#ff80ff",
    "10": "#b3ffb3",
    "11": "#ff8080",
    "12": "#ffffbf",
    "13": "#000080",
    "14": "#808000",
    "15": "#00ffff",
}
m = leafmap.Map()
m.add_cog_layer(url, colormap=custom_cmap, name="El_Salvador")
legend_dict = dict(zip([int(key) for key in custom_cmap.keys()], custom_cmap.values()))
m.add_legend(title="Landcover", legend_dict=legend_dict)
m
```
![image](https://github.com/user-attachments/assets/cbf70887-2aec-44cd-bfba-3663f020b77f)


