### PR TITLE
Add support for d2s

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -14117,3 +14117,32 @@ def ee_tile_url(
         except Exception as e:
             print(e)
             return None
+
+
+def d2s_tile(
+    url: str, titiler_endpoint: str = "https://tt.d2s.org", **kwargs: Any
+) -> str:
+    """Generate a D2S tile URL with optional API key.
+
+    Args:
+        url (str): The base URL for the tile.
+        titiler_endpoint (str, optional): The endpoint for the titiler service.
+            Defaults to "https://tt.d2s.org".
+        **kwargs (Any): Additional keyword arguments to pass to the cog_stats function.
+
+    Returns:
+        str: The modified URL with the API key if required, otherwise the original URL.
+
+    Raises:
+        ValueError: If the API key is required but not set in the environment variables.
+    """
+
+    stats = cog_stats(url, titiler_endpoint=titiler_endpoint, **kwargs)
+    if "detail" in stats:
+        api_key = get_api_key("D2S_API_KEY")
+        if api_key is None:
+            raise ValueError("Please set the D2S_API_KEY environment variable.")
+        else:
+            return f"{url}?API_KEY={api_key}"
+    else:
+        return url

--- a/leafmap/maplibregl.py
+++ b/leafmap/maplibregl.py
@@ -966,7 +966,7 @@ class Map(MapWidget):
         visible: bool = True,
         bands: Optional[List[int]] = None,
         nodata: Optional[Union[int, float]] = 0,
-        titiler_endpoint: str = "https://titiler.xyz",
+        titiler_endpoint: str = None,
         fit_bounds: bool = True,
         before_id: Optional[str] = None,
         **kwargs: Any,


### PR DESCRIPTION

```python
import os
import leafmap

# os.environ["D2S_API_KEY"] = "YOUR-API-KEY"
os.environ["TITILER_ENDPOINT"] = "https://tt.d2s.org"

m = leafmap.Map()
m.add_basemap("Satellite")
ortho_url = "https://ps2.d2s.org/static/projects/afc5005d-4977-4bdd-a53a-96a3f051d312/flights/32607eae-0cd9-4c06-b4d1-a4837d237ce1/data_products/0e4c3bc2-00da-41b3-bf79-d1d1f83e4194/bb62658b-a250-46e2-8e93-081828880634.tif"
url = leafmap.d2s_tile(ortho_url)
m.add_cog_layer(url, name="Image", nodata=0)
m
```