### PR TITLE
Add support for overture data

### DIFF
--- a/docs/maplibre/overture.ipynb
+++ b/docs/maplibre/overture.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "For more information about Overture data, see https://github.com/OvertureMaps/overture-tiles\n",
     "\n",
-    "## Buildings"
+    "## 3D Buildings"
    ]
   },
   {
@@ -51,22 +51,143 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = \"https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/2024-07-22/buildings.pmtiles\""
+    "m = leafmap.Map(\n",
+    "    center=[-74.0095, 40.7046], zoom=16, pitch=60, bearing=-17, style=\"positron\"\n",
+    ")\n",
+    "m.add_basemap(\"Esri.WorldImagery\", visible=False)\n",
+    "m.add_overture_3d_buildings(release=\"2024-07-22\", template=\"simple\")\n",
+    "m.add_layer_control()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## 2D buildings"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = leafmap.Map(\n",
-    "    center=[-74.0095, 40.7046], zoom=16, pitch=60, bearing=-17, style=\"positron\"\n",
-    ")\n",
-    "m.add_basemap(\"OpenStreetMap.Mapnik\")\n",
+    "m = leafmap.Map(center=[-74.0095, 40.7046], zoom=16)\n",
     "m.add_basemap(\"Esri.WorldImagery\", visible=False)\n",
-    "m.add_overture_3d_buildings(url, template=\"simple\")\n",
+    "m.add_overture_data(theme=\"buildings\", opacity=0.8)\n",
+    "m.add_layer_control()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Transportation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[-74.0095, 40.7046], zoom=16)\n",
+    "m.add_basemap(\"Esri.WorldImagery\", visible=False)\n",
+    "m.add_overture_data(theme=\"transportation\", opacity=0.8)\n",
+    "m.add_layer_control()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Places"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[-74.0095, 40.7046], zoom=16)\n",
+    "m.add_basemap(\"Esri.WorldImagery\", visible=False)\n",
+    "m.add_overture_data(theme=\"places\", opacity=0.8)\n",
+    "m.add_layer_control()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Addresses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[-74.0095, 40.7046], zoom=16)\n",
+    "m.add_basemap(\"Esri.WorldImagery\", visible=False)\n",
+    "m.add_overture_data(theme=\"addresses\", opacity=0.8)\n",
+    "m.add_layer_control()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## Base"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[-74.0095, 40.7046], zoom=16)\n",
+    "m.add_basemap(\"Esri.WorldImagery\", visible=False)\n",
+    "m.add_overture_data(theme=\"base\", opacity=0.8)\n",
+    "m.add_layer_control()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "## Divisions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map()\n",
+    "m.add_basemap(\"Esri.WorldImagery\", visible=False)\n",
+    "m.add_overture_data(theme=\"divisions\", opacity=0.8)\n",
     "m.add_layer_control()\n",
     "m"
    ]

--- a/docs/maplibre/overture.ipynb
+++ b/docs/maplibre/overture.ipynb
@@ -65,13 +65,21 @@
    "id": "5",
    "metadata": {},
    "source": [
+    "![](https://github.com/user-attachments/assets/e07986eb-cc5a-4f25-b7e0-bed480a415d3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
     "## 2D buildings"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Transportation"
@@ -93,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Places"
@@ -115,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Addresses"
@@ -137,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Base"
@@ -159,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Divisions"
@@ -181,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/maplibre/overture.ipynb
+++ b/docs/maplibre/overture.ipynb
@@ -1,0 +1,112 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "[![image](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://demo.leafmap.org/lab/index.html?path=maplibre/overture.ipynb)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/docs/maplibre/overture.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)\n",
+    "\n",
+    "**Visualize Overture data**\n",
+    "\n",
+    "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install -U \"leafmap[maplibre]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import leafmap.maplibregl as leafmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43d23342-68bc-4761-b5ac-7e67c5c08e7c",
+   "metadata": {},
+   "source": [
+    "For more information about Overture data, see https://github.com/OvertureMaps/overture-tiles\n",
+    "\n",
+    "## Buildings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "aeeb7410-eeb2-4cd6-99fe-dbe5dedb0077",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/2024-07-22/buildings.pmtiles\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "db3e0cd0-d4f5-4ac7-93a1-cedae9217fd2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5882c8d7c5a74aea94ec4a415d19c016",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Map(height='600px', map_options={'bearing': -17, 'center': (-74.0095, 40.7046), 'pitch': 60, 'style': 'https:/…"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m = leafmap.Map(\n",
+    "    center=[-74.0095, 40.7046], zoom=16, pitch=60, bearing=-17, style=\"positron\"\n",
+    ")\n",
+    "m.add_basemap(\"OpenStreetMap.Mapnik\")\n",
+    "m.add_basemap(\"Esri.WorldImagery\", visible=False)\n",
+    "m.add_overture_3d_buildings(url, template=\"simple\")\n",
+    "m.add_layer_control()\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/maplibre/overture.ipynb
+++ b/docs/maplibre/overture.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1",
    "metadata": {},
    "outputs": [],
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "2",
    "metadata": {},
    "outputs": [],
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43d23342-68bc-4761-b5ac-7e67c5c08e7c",
+   "id": "3",
    "metadata": {},
    "source": [
     "For more information about Overture data, see https://github.com/OvertureMaps/overture-tiles\n",
@@ -46,8 +46,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "aeeb7410-eeb2-4cd6-99fe-dbe5dedb0077",
+   "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,26 +56,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "db3e0cd0-d4f5-4ac7-93a1-cedae9217fd2",
+   "execution_count": null,
+   "id": "5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5882c8d7c5a74aea94ec4a415d19c016",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/plain": [
-       "Map(height='600px', map_options={'bearing': -17, 'center': (-74.0095, 40.7046), 'pitch': 60, 'style': 'https:/…"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m = leafmap.Map(\n",
     "    center=[-74.0095, 40.7046], zoom=16, pitch=60, bearing=-17, style=\"positron\"\n",

--- a/docs/maplibre/overview.md
+++ b/docs/maplibre/overview.md
@@ -410,6 +410,14 @@ Visualize ocean bathymetry in 3D.
 
 [![](https://i.imgur.com/m6NwSWG.png)](https://leafmap.org/maplibre/ocean_bathymetry)
 
+## Visualze Overture data
+
+Visualize Overture Maps data.
+
+[![](https://i.imgur.com/m6NwSWG.png)](https://leafmap.org/maplibre/ocean_bathymetry)
+
+[![](https://github.com/user-attachments/assets/e07986eb-cc5a-4f25-b7e0-bed480a415d3)](https://leafmap.org/maplibre/overture)
+
 ## PMTiles source and protocol
 
 Uses the PMTiles plugin and protocol to present a map.

--- a/leafmap/maplibregl.py
+++ b/leafmap/maplibregl.py
@@ -2756,7 +2756,7 @@ class Map(MapWidget):
 
     def add_overture_3d_buildings(
         self,
-        url: Optional[str] = None,
+        release: Optional[str] = "2024-07-22",
         style: Optional[Dict[str, Any]] = None,
         values: Optional[List[int]] = None,
         colors: Optional[List[str]] = None,
@@ -2765,12 +2765,14 @@ class Map(MapWidget):
         tooltip: bool = True,
         template: str = "simple",
         fit_bounds: bool = False,
+        **kwargs: Any,
     ) -> None:
         """Add 3D buildings from Overture Maps to the map.
 
         Args:
-            url (Optional[str], optional): The URL of the PMTiles file. Defaults to None.
-                For more info, see https://github.com/OvertureMaps/overture-tiles.
+            release (Optional[str], optional): The release date of the Overture Maps data.
+                Defaults to "2024-07-22". For more info, see
+                https://github.com/OvertureMaps/overture-tiles.
             style (Optional[Dict[str, Any]], optional): The style dictionary for
                 the buildings. Defaults to None.
             values (Optional[List[int]], optional): List of height values for
@@ -2791,8 +2793,7 @@ class Map(MapWidget):
         Raises:
             ValueError: If the length of values and colors lists are not the same.
         """
-        if url is None:
-            url = "https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/2024-07-22/buildings.pmtiles"
+        url = f"https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/{release}/buildings.pmtiles"
 
         if template == "simple":
             template = "Name: {{@name}}<br>Subtype: {{subtype}}<br>Class: {{class}}<br>Height: {{height}}"
@@ -2865,6 +2866,249 @@ class Map(MapWidget):
             tooltip=tooltip,
             template=template,
             fit_bounds=fit_bounds,
+            **kwargs,
+        )
+
+    def add_overture_data(
+        self,
+        release: str = "2024-07-22",
+        theme: str = "buildings",
+        style: Optional[Dict[str, Any]] = None,
+        visible: bool = True,
+        opacity: float = 1.0,
+        tooltip: bool = True,
+        fit_bounds: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Add Overture Maps data to the map.
+
+        Args:
+            release (str, optional): The release date of the data. Defaults to
+                "2024-07-22". For more info, see https://github.com/OvertureMaps/overture-tiles
+            theme (str, optional): The theme of the data. It can be one of the following:
+                "addresses", "base", "buildings", "divisions", "places", "transportation".
+                Defaults to "buildings".
+            style (Optional[Dict[str, Any]], optional): The style dictionary for
+                the data. Defaults to None.
+            visible (bool, optional): Whether the data layer is visible. Defaults to True.
+            opacity (float, optional): The opacity of the data layer. Defaults to 1.0.
+            tooltip (bool, optional): Whether to show tooltips on the data.
+                Defaults to True.
+            fit_bounds (bool, optional): Whether to fit the map bounds to the
+                data layer. Defaults to False.
+            **kwargs (Any): Additional keyword arguments for the add_pmtiles method.
+
+        Raises:
+            ValueError: If the theme is not one of the allowed themes.
+        """
+
+        allowed_themes = [
+            "addresses",
+            "base",
+            "buildings",
+            "divisions",
+            "places",
+            "transportation",
+        ]
+        if theme not in allowed_themes:
+            raise ValueError(
+                f"The theme must be one of the following: {', '.join(allowed_themes)}"
+            )
+
+        styles = {
+            "addresses": {
+                "layers": [
+                    {
+                        "id": "Address",
+                        "source": "example_source",
+                        "source-layer": "address",
+                        "type": "circle",
+                        "paint": {
+                            "circle-radius": 4,
+                            "circle-color": "#8dd3c7",
+                            "circle-stroke-color": "#8dd3c7",
+                            "circle-stroke-width": 1,
+                        },
+                    },
+                ]
+            },
+            "base": {
+                "layers": [
+                    {
+                        "id": "Infrastructure",
+                        "source": "example_source",
+                        "source-layer": "infrastructure",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#8DD3C7",
+                            "fill-opacity": 1.0,
+                            "fill-outline-color": "#888888",
+                        },
+                    },
+                    {
+                        "id": "Land",
+                        "source": "example_source",
+                        "source-layer": "land",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#FFFFB3",
+                            "fill-opacity": 1.0,
+                            "fill-outline-color": "#888888",
+                        },
+                    },
+                    {
+                        "id": "Land_cover",
+                        "source": "example_source",
+                        "source-layer": "land_cover",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#BEBADA",
+                            "fill-opacity": 1.0,
+                            "fill-outline-color": "#888888",
+                        },
+                    },
+                    {
+                        "id": "Land_use",
+                        "source": "example_source",
+                        "source-layer": "land_use",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#FB8072",
+                            "fill-opacity": 1.0,
+                            "fill-outline-color": "#888888",
+                        },
+                    },
+                    {
+                        "id": "Water",
+                        "source": "example_source",
+                        "source-layer": "water",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#80B1D3",
+                            "fill-opacity": 1.0,
+                            "fill-outline-color": "#888888",
+                        },
+                    },
+                ]
+            },
+            "buildings": {
+                "layers": [
+                    {
+                        "id": "Building",
+                        "source": "example_source",
+                        "source-layer": "building",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#6ea299",
+                            "fill-opacity": 1.0,
+                            "fill-outline-color": "#888888",
+                        },
+                    },
+                    {
+                        "id": "Building_part",
+                        "source": "example_source",
+                        "source-layer": "building_part",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#fdfdb2",
+                            "fill-opacity": 1.0,
+                            "fill-outline-color": "#888888",
+                        },
+                    },
+                ]
+            },
+            "divisions": {
+                "layers": [
+                    {
+                        "id": "Division",
+                        "source": "example_source",
+                        "source-layer": "division",
+                        "type": "circle",
+                        "paint": {
+                            "circle-radius": 4,
+                            "circle-color": "#8dd3c7",
+                            "circle-stroke-color": "#8dd3c7",
+                            "circle-stroke-width": 1,
+                        },
+                    },
+                    {
+                        "id": "Division_area",
+                        "source": "example_source",
+                        "source-layer": "division_area",
+                        "type": "fill",
+                        "paint": {
+                            "fill-color": "#FFFFB3",
+                            "fill-opacity": 1.0,
+                            "fill-outline-color": "#888888",
+                        },
+                    },
+                    {
+                        "id": "Division_boundary",
+                        "source": "example_source",
+                        "source-layer": "division_boundary",
+                        "type": "line",
+                        "paint": {
+                            "line-color": "#BEBADA",
+                            "line-width": 1.0,
+                        },
+                    },
+                ]
+            },
+            "places": {
+                "layers": [
+                    {
+                        "id": "Place",
+                        "source": "example_source",
+                        "source-layer": "place",
+                        "type": "circle",
+                        "paint": {
+                            "circle-radius": 4,
+                            "circle-color": "#8dd3c7",
+                            "circle-stroke-color": "#8dd3c7",
+                            "circle-stroke-width": 1,
+                        },
+                    },
+                ]
+            },
+            "transportation": {
+                "layers": [
+                    {
+                        "id": "Segment",
+                        "source": "example_source",
+                        "source-layer": "segment",
+                        "type": "line",
+                        "paint": {
+                            "line-color": "#ffffb3",
+                            "line-width": 1.0,
+                        },
+                    },
+                    {
+                        "id": "Connector",
+                        "source": "example_source",
+                        "source-layer": "connector",
+                        "type": "circle",
+                        "paint": {
+                            "circle-radius": 4,
+                            "circle-color": "#8dd3c7",
+                            "circle-stroke-color": "#8dd3c7",
+                            "circle-stroke-width": 1,
+                        },
+                    },
+                ]
+            },
+        }
+
+        url = f"https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/{release}/{theme}.pmtiles"
+        if style is None:
+            style = styles.get(theme, None)
+        self.add_pmtiles(
+            url,
+            style=style,
+            visible=visible,
+            opacity=opacity,
+            tooltip=tooltip,
+            fit_bounds=fit_bounds,
+            **kwargs,
         )
 
     def add_video(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -209,6 +209,7 @@ nav:
           - maplibre/multiple_geometries.ipynb
           - maplibre/navigation.ipynb
           - maplibre/ocean_bathymetry.ipynb
+          - maplibre/overture.ipynb
           - maplibre/pmtiles.ipynb
           - maplibre/restrict_bounds.ipynb
           - maplibre/satellite_map.ipynb


### PR DESCRIPTION
```python
import leafmap.maplibregl as leafmap
m = leafmap.Map(
    center=[-74.0095, 40.7046], zoom=16, pitch=60, bearing=-17, style="positron"
)
m.add_basemap("OpenStreetMap.Mapnik")
m.add_basemap("Esri.WorldImagery", visible=False)
m.add_overture_3d_buildings(release="2024-07-22", template="simple")
m.add_layer_control()
m
```
[![](https://github.com/user-attachments/assets/e07986eb-cc5a-4f25-b7e0-bed480a415d3)](https://leafmap.org/maplibre/overture)