### PR TITLE
Need to add titiler_endpoint argument when calling cog_tile_vmin_vmax in add_cog_layer

### DIFF
--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -1040,7 +1040,9 @@ class Map(ipyleaflet.Map):
         if not hasattr(self, "cog_layer_dict"):
             self.cog_layer_dict = {}
 
-        vmin, vmax = cog_tile_vmin_vmax(url, bands=bands, titiler_endpoint=titiler_endpoint)
+        vmin, vmax = cog_tile_vmin_vmax(
+            url, bands=bands, titiler_endpoint=titiler_endpoint
+        )
 
         if "colormap_name" in kwargs:
             colormap = kwargs["colormap_name"]

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -1040,7 +1040,7 @@ class Map(ipyleaflet.Map):
         if not hasattr(self, "cog_layer_dict"):
             self.cog_layer_dict = {}
 
-        vmin, vmax = cog_tile_vmin_vmax(url, bands=bands)
+        vmin, vmax = cog_tile_vmin_vmax(url, bands=bands, titiler_endpoint=titiler_endpoint)
 
         if "colormap_name" in kwargs:
             colormap = kwargs["colormap_name"]


### PR DESCRIPTION
Fixed a problem when running ```add_cog_layer``` with **custom titiler_endpoint.**

When a user run ```add_cog_layer``` with custom titiler_endpoint, the user will encounter following error message.

```
---------------------------------------------------------------------------
File ~/Desktop/workspace/leafmap/leafmap/stac.py:246, in cog_tile_vmin_vmax(url, bands, titiler_endpoint, percentile, **kwargs)
    [243](https://file+.vscode-resource.vscode-cdn.net/Users/swham/Desktop/workspace/leafmap/~/Desktop/workspace/leafmap/leafmap/stac.py:243)     stats = {s: stats[s] for s in stats if s in bands}
    [245](https://file+.vscode-resource.vscode-cdn.net/Users/swham/Desktop/workspace/leafmap/~/Desktop/workspace/leafmap/leafmap/stac.py:245) if percentile:
--> [246](https://file+.vscode-resource.vscode-cdn.net/Users/swham/Desktop/workspace/leafmap/~/Desktop/workspace/leafmap/leafmap/stac.py:246)     vmin = min([stats[s]["percentile_2"] for s in stats])
    [247](https://file+.vscode-resource.vscode-cdn.net/Users/swham/Desktop/workspace/leafmap/~/Desktop/workspace/leafmap/leafmap/stac.py:247)     vmax = max([stats[s]["percentile_98"] for s in stats])
    [248](https://file+.vscode-resource.vscode-cdn.net/Users/swham/Desktop/workspace/leafmap/~/Desktop/workspace/leafmap/leafmap/stac.py:248) else:

TypeError: string indices must be integers, not 'str'
```

This error is occured in ```leafmap.stac.cog_tile_vmin_vmax``` function due to wrong response from titiler. However, although the user provided the custom titiler_endpoint, this is not passed to the function, so the function tries to retrieve environment variable named TITILER_ENDPOINT. As a result, this function sends request to another URL rather than the URL that the user wants.

The problem can be simply solved by adding titiler_endpoint argument when calling ```leafmap.stac.cog_tile_vmin_vmax``` function in ```add_cog_layer```.