### PR TITLE
Improve add_stac_layer to support pystac.Item

### DIFF
--- a/leafmap/stac.py
+++ b/leafmap/stac.py
@@ -562,6 +562,12 @@ def stac_tile(
     if collection is not None and titiler_endpoint is None:
         titiler_endpoint = "planetary-computer"
 
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
+
     if url is not None:
         kwargs["url"] = url
     if collection is not None:
@@ -737,6 +743,12 @@ def stac_bounds(
     if collection is not None and titiler_endpoint is None:
         titiler_endpoint = "planetary-computer"
 
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
+
     if url is not None:
         kwargs["url"] = url
         response = requests.get(url)
@@ -779,6 +791,13 @@ def stac_center(
     Returns:
         tuple: A tuple representing (longitude, latitude)
     """
+
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
+
     bounds = stac_bounds(url, collection, item, titiler_endpoint, **kwargs)
     center = ((bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2)  # (lon, lat)
     return center
@@ -808,6 +827,12 @@ def stac_bands(
 
     if collection is not None and titiler_endpoint is None:
         titiler_endpoint = "planetary-computer"
+
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
 
     if url is not None:
         kwargs["url"] = url
@@ -851,6 +876,12 @@ def stac_stats(
 
     if collection is not None and titiler_endpoint is None:
         titiler_endpoint = "planetary-computer"
+
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
 
     if url is not None:
         kwargs["url"] = url
@@ -933,6 +964,12 @@ def stac_info(
     if collection is not None and titiler_endpoint is None:
         titiler_endpoint = "planetary-computer"
 
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
+
     if url is not None:
         kwargs["url"] = url
     if collection is not None:
@@ -978,6 +1015,12 @@ def stac_info_geojson(
     if collection is not None and titiler_endpoint is None:
         titiler_endpoint = "planetary-computer"
 
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
+
     if url is not None:
         kwargs["url"] = url
     if collection is not None:
@@ -1022,6 +1065,12 @@ def stac_assets(
 
     if collection is not None and titiler_endpoint is None:
         titiler_endpoint = "planetary-computer"
+
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
 
     if url is not None:
         kwargs["url"] = url
@@ -1071,6 +1120,12 @@ def stac_pixel_value(
 
     if collection is not None and titiler_endpoint is None:
         titiler_endpoint = "planetary-computer"
+
+    if isinstance(url, pystac.Item):
+        try:
+            url = url.self_href
+        except Exception as e:
+            print(e)
 
     if url is not None:
         kwargs["url"] = url


### PR DESCRIPTION
Fix #940 

```python
import leafmap

url = "https://earth-search.aws.element84.com/v1/"
collection = "sentinel-2-l2a"
time_range = "2020-12-01/2020-12-31"
bbox = [-122.2751, 47.5469, -121.9613, 47.7458]
result = leafmap.stac_search(
    url=url,
    max_items=10,
    collections=[collection],
    bbox=bbox,
    datetime=time_range,
    query={"eo:cloud_cover": {"lt": 10}},
    sortby=[{"field": "properties.eo:cloud_cover", "direction": "asc"}],
)
item = result.get_all_items()[-1]
m = leafmap.Map()
m.add_stac_layer(item, assets=["nir", "red", "green"])
m
```
![image](https://github.com/user-attachments/assets/a726a527-3fdd-4ee9-8cba-bd15eafaa338)
