### PR TITLE
Add support for line and circle legend items

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -6789,6 +6789,7 @@ def create_legend(
     draggable=True,
     output=None,
     style={},
+    shape_type="rectangle",
 ):
     """Create a legend in HTML format. Reference: https://bit.ly/3oV6vnH
 
@@ -7014,6 +7015,14 @@ def create_legend(
                 content.append(line)
 
     legend_text = "".join(content)
+    if shape_type == "circle":
+        legend_text = legend_text.replace("width: 30px", "width: 16px")
+        legend_text = legend_text.replace(
+            "border: 1px solid #999;",
+            "border-radius: 50%;\n      border: 1px solid #999;",
+        )
+    elif shape_type == "line":
+        legend_text = legend_text.replace("height: 16px", "height: 3px")
 
     if output is not None:
         with open(output, "w") as f:

--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -1231,6 +1231,7 @@ class Map(folium.Map):
         position: Optional[str] = "bottomright",
         draggable: Optional[bool] = True,
         style: Optional[Dict] = {},
+        shape_type: Optional[str] = "rectangle",
     ):
         """Adds a customized legend to the map. Reference: https://bit.ly/3oV6vnH.
             If you want to add multiple legends to the map, you need to set the `draggable` argument to False.
@@ -1260,6 +1261,8 @@ class Map(folium.Map):
                     'bottom': '20px',
                     'right': '5px'
                 }
+            shape_type (str, optional): The shape type of the legend item. It can be
+                either "rectangle", "line" or "circle". Defaults to "rectangle".
 
         """
         content = create_legend(
@@ -1272,6 +1275,7 @@ class Map(folium.Map):
             position,
             draggable,
             style=style,
+            shape_type=shape_type,
         )
         if draggable:
             from branca.element import Template, MacroElement

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -1784,6 +1784,7 @@ class Map(ipyleaflet.Map):
         position: Optional[str] = "bottomright",
         builtin_legend: Optional[str] = None,
         layer_name: Optional[str] = None,
+        shape_type: Optional[str] = "rectangle",
         **kwargs,
     ) -> None:
         """Adds a customized basemap to the map.
@@ -1934,6 +1935,15 @@ class Map(ipyleaflet.Map):
 
         legend_html = header + content + footer
         legend_text = "".join(legend_html)
+
+        if shape_type == "circle":
+            legend_text = legend_text.replace("width: 30px", "width: 16px")
+            legend_text = legend_text.replace(
+                "border: 1px solid #999;",
+                "border-radius: 50%;\n      border: 1px solid #999;",
+            )
+        elif shape_type == "line":
+            legend_text = legend_text.replace("height: 16px", "height: 3px")
 
         try:
             legend_output_widget = widgets.Output(

--- a/leafmap/map_widgets.py
+++ b/leafmap/map_widgets.py
@@ -169,6 +169,7 @@ class Legend(ipywidgets.VBox):
         position="bottomright",
         builtin_legend=None,
         add_header=True,
+        shape_type="rectangle",
         widget_args={},
         **kwargs,
     ):
@@ -187,6 +188,7 @@ class Legend(ipywidgets.VBox):
                 to the map. Defaults to None.
             add_header (bool, optional): Whether the legend can be closed or
                 not. Defaults to True.
+            shape_type (str, optional): The shape type of the legend item.
             widget_args (dict, optional): Additional arguments passed to the
                 widget_template() function. Defaults to {}.
 
@@ -273,6 +275,15 @@ class Legend(ipywidgets.VBox):
 
         legend_html = header + content + footer
         legend_text = "".join(legend_html)
+
+        if shape_type == "circle":
+            legend_text = legend_text.replace("width: 30px", "width: 16px")
+            legend_text = legend_text.replace(
+                "border: 1px solid #999;",
+                "border-radius: 50%;\n      border: 1px solid #999;",
+            )
+        elif shape_type == "line":
+            legend_text = legend_text.replace("height: 16px", "height: 3px")
         legend_output = ipywidgets.Output(layout=Legend.__create_layout(**kwargs))
         legend_widget = ipywidgets.HTML(value=legend_text)
 

--- a/leafmap/maplibregl.py
+++ b/leafmap/maplibregl.py
@@ -2513,6 +2513,7 @@ class Map(MapWidget):
         bg_color: str = "white",
         position: str = "bottom-right",
         builtin_legend: Optional[str] = None,
+        shape_type: str = "rectangle",
         **kwargs: Union[str, int, float],
     ) -> None:
         """
@@ -2534,6 +2535,7 @@ class Map(MapWidget):
             position (str, optional): The position of the legend on the map. Can be one of "top-left",
                 "top-right", "bottom-left", "bottom-right". Defaults to "bottom-right".
             builtin_legend (Optional[str], optional): The name of a built-in legend to use. Defaults to None.
+            shape_type (str, optional): The shape type of the legend items. Can be one of "rectangle", "circle", or "line".
             **kwargs: Additional keyword arguments for future use.
 
         Returns:
@@ -2647,6 +2649,15 @@ class Map(MapWidget):
 
         legend_html = header + content + footer
         legend_text = "".join(legend_html)
+
+        if shape_type == "circle":
+            legend_text = legend_text.replace("width: 30px", "width: 16px")
+            legend_text = legend_text.replace(
+                "border: 1px solid #999;",
+                "border-radius: 50%;\n      border: 1px solid #999;",
+            )
+        elif shape_type == "line":
+            legend_text = legend_text.replace("height: 16px", "height: 3px")
 
         self.add_html(
             legend_text,


### PR DESCRIPTION

```python
m = leafmap.Map()
m.add_basemap("NLCD 2019 CONUS Land Cover")
m.add_legend(title="NLCD Land Cover Classification", builtin_legend="NLCD", shape_type="circle") # line or rectangle
m
```

![image](https://github.com/user-attachments/assets/15ac91e8-2cc8-4137-aee3-b01b21c979b2)
