### PR TITLE
improvement: support marimo notebooks

### DIFF
--- a/leafmap/__init__.py
+++ b/leafmap/__init__.py
@@ -18,9 +18,21 @@ def _in_colab_shell():
         return False
 
 
+def _in_marimo():
+    """Tests if the code is being executed within a marimo notebook."""
+    try:
+        import marimo
+        return marimo.running_in_notebook()
+    except (ImportError, ModuleNotFoundError):
+        # marimo not installed
+        return False
+
+
 def _use_folium():
     """Whether to use the folium or ipyleaflet plotting backend."""
     if os.environ.get("USE_MKDOCS") is not None:
+        return True
+    elif _in_marimo():
         return True
     else:
         return False

--- a/leafmap/__init__.py
+++ b/leafmap/__init__.py
@@ -22,6 +22,7 @@ def _in_marimo():
     """Tests if the code is being executed within a marimo notebook."""
     try:
         import marimo
+
         return marimo.running_in_notebook()
     except (ImportError, ModuleNotFoundError):
         # marimo not installed


### PR DESCRIPTION
[marimo](https://github.com/marimo-team/marimo) notebooks need to use `folium` instead of `ipyleaflet` as the default backend. This check would allow users to copy/paste the examples on the leamap docs without modifying the code
