### PR TITLE
Remove dependency on plotly in foliummap

### DIFF
--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -9,7 +9,6 @@ from .basemaps import xyz_to_folium
 from .osm import *
 from . import examples
 from .map_widgets import *
-from .plot import *
 
 from branca.element import Figure, JavascriptLink, MacroElement
 from folium.elements import JSCSSMixin


### PR DESCRIPTION
Given the `*` import, it is a bit hard to trace, but I don't think this imoprt is used. Removing this means the foliummap does not need to depend on plotly being installed. 