### PR TITLE
Fix issue if xarray/rioxarray dataset does not have a crs value

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -10510,7 +10510,8 @@ def array_to_memory_file(
             )
         if hasattr(array, "rio"):
             if hasattr(array.rio, "crs"):
-                crs = array.rio.crs
+                if array.rio.crs is not None:
+                    crs = array.rio.crs
             if transform is None and hasattr(array.rio, "transform"):
                 transform = array.rio.transform()
         elif source is None:


### PR DESCRIPTION
Adds a check to the `array_to_memory_file` function that verifies if the crs provided by the array (from `array.rio.crs`) is not None. 

Without it, there is no way to overwrite the crs using the keyword arguments of the `array_to_memory_file` function and as a consequence the given error message ("crs must be provided if source is not provided, such as EPSG:3857") is confusing because setting the `crs` argument has no effect.


Just for completeness, the current workaround would be to set crs before calling array_to_memory_file
```
array.rio.write_crs("EPSG:3857", inplace=True)
```

