### PR TITLE
Handle `osmnx.features_from_bbox` interface change

### DIFF
--- a/leafmap/osm.py
+++ b/leafmap/osm.py
@@ -293,7 +293,7 @@ def osm_gdf_from_bbox(north: float, south: float, east: float, west: float, tags
             "osmnx package is required. Please install it using 'pip install osmnx'"
         )
 
-    gdf = ox.features_from_bbox(north, south, east, west, tags)
+    gdf = ox.features_from_bbox(north=north, south=south, east=east, west=west, tags=tags)
     return gdf
 
 

--- a/leafmap/osm.py
+++ b/leafmap/osm.py
@@ -293,7 +293,9 @@ def osm_gdf_from_bbox(north: float, south: float, east: float, west: float, tags
             "osmnx package is required. Please install it using 'pip install osmnx'"
         )
 
-    gdf = ox.features_from_bbox(north=north, south=south, east=east, west=west, tags=tags)
+    gdf = ox.features_from_bbox(
+        north=north, south=south, east=east, west=west, tags=tags
+    )
     return gdf
 
 


### PR DESCRIPTION
Handle the addition of `bbox` as an argument to `osmnx.features_from_bbox` (https://github.com/gboeing/osmnx/pull/1112) in v1.9.0 and onwards:
https://github.com/gboeing/osmnx/blob/d2a88cd708a23515be882ee85a4a55e420be61f6/osmnx/features.py#L82-L103