### PR TITLE
adding in resolution and zoom functionality to the map_tiles_to_geotiff

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -9340,17 +9340,30 @@ def map_tiles_to_geotiff(
             'source must be one of "OpenStreetMap", "ROADMAP", "SATELLITE", "TERRAIN", "HYBRID", or a URL'
         )
 
+    # Web Mercator tile size in meters at zoom level 0
+    MERCATOR_ZOOM_0_RESOLUTION_M = 156543.03392804097
+
     def resolution_to_zoom_level(resolution):
         """
         Convert map resolution in meters to zoom level for Web Mercator (EPSG:3857) tiles.
         """
-        # Web Mercator tile size in meters at zoom level 0
-        initial_resolution = 156543.03392804097
+        initial_resolution = MERCATOR_ZOOM_0_RESOLUTION_M
 
         # Calculate the zoom level
         zoom_level = math.log2(initial_resolution / resolution)
 
         return int(zoom_level)
+    
+    def zoom_level_to_resolution(zoom):
+        """
+        Convert map zoom level to resolution in meters for Web Mercator (EPSG:3857) tiles.
+        """
+        initial_resolution = MERCATOR_ZOOM_0_RESOLUTION_M
+
+        # Calculate resolution
+        resolution_m = initial_resolution / (2**zoom)
+        
+        return resolution_m
 
     if isinstance(bbox, list) and len(bbox) == 4:
         west, south, east, north = bbox
@@ -9359,13 +9372,17 @@ def map_tiles_to_geotiff(
             "bbox must be a list of 4 coordinates in the format of [xmin, ymin, xmax, ymax]"
         )
 
-    if zoom is None and resolution is None:
+    if (zoom is None) and (resolution is None):
         raise ValueError("Either zoom or resolution must be provided")
-    elif zoom is not None and resolution is not None:
+    
+    elif (zoom is not None) and (resolution is not None):
         raise ValueError("Only one of zoom or resolution can be provided")
-
-    if resolution is not None:
+    
+    elif (zoom is None) and (resolution is not None):
         zoom = resolution_to_zoom_level(resolution)
+    else:
+        # condition: (resolution is None) and (zoom is not None):
+        resolution = zoom_level_to_resolution(zoom)
 
     EARTH_EQUATORIAL_RADIUS = 6378137.0
 
@@ -9523,6 +9540,12 @@ def map_tiles_to_geotiff(
             gdal.GDT_Byte,
             **kwargs,
         )
+
+        gtiff.SetMetadata({
+            "ZOOM_LEVEL": str(zoom),
+            "RESOLUTION_M": str(resolution)
+        })
+
         xp0, yp0 = from4326_to3857(lat0, lon0)
         xp1, yp1 = from4326_to3857(lat1, lon1)
         pwidth = abs(xp1 - xp0) / img.size[0]
@@ -9543,9 +9566,12 @@ def map_tiles_to_geotiff(
     try:
         draw_tile(source, south, west, north, east, zoom, output, quiet, **kwargs)
         if crs.upper() != "EPSG:3857":
-            reproject(output, output, crs, to_cog=to_cog)
+            reproject(image=output,
+                      output=output,
+                      dst_crs=crs,
+                      to_cog=to_cog)
         elif to_cog:
-            image_to_cog(output, output)
+            image_to_cog(source=output, dst_path=output)
     except Exception as e:
         raise Exception(e)
 

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -9353,7 +9353,7 @@ def map_tiles_to_geotiff(
         zoom_level = math.log2(initial_resolution / resolution)
 
         return int(zoom_level)
-    
+
     def zoom_level_to_resolution(zoom):
         """
         Convert map zoom level to resolution in meters for Web Mercator (EPSG:3857) tiles.
@@ -9362,7 +9362,7 @@ def map_tiles_to_geotiff(
 
         # Calculate resolution
         resolution_m = initial_resolution / (2**zoom)
-        
+
         return resolution_m
 
     if isinstance(bbox, list) and len(bbox) == 4:
@@ -9374,10 +9374,10 @@ def map_tiles_to_geotiff(
 
     if (zoom is None) and (resolution is None):
         raise ValueError("Either zoom or resolution must be provided")
-    
+
     elif (zoom is not None) and (resolution is not None):
         raise ValueError("Only one of zoom or resolution can be provided")
-    
+
     elif (zoom is None) and (resolution is not None):
         zoom = resolution_to_zoom_level(resolution)
     else:
@@ -9541,10 +9541,7 @@ def map_tiles_to_geotiff(
             **kwargs,
         )
 
-        gtiff.SetMetadata({
-            "ZOOM_LEVEL": str(zoom),
-            "RESOLUTION_M": str(resolution)
-        })
+        gtiff.SetMetadata({"ZOOM_LEVEL": str(zoom), "RESOLUTION_M": str(resolution)})
 
         xp0, yp0 = from4326_to3857(lat0, lon0)
         xp1, yp1 = from4326_to3857(lat1, lon1)
@@ -9566,10 +9563,7 @@ def map_tiles_to_geotiff(
     try:
         draw_tile(source, south, west, north, east, zoom, output, quiet, **kwargs)
         if crs.upper() != "EPSG:3857":
-            reproject(image=output,
-                      output=output,
-                      dst_crs=crs,
-                      to_cog=to_cog)
+            reproject(image=output, output=output, dst_crs=crs, to_cog=to_cog)
         elif to_cog:
             image_to_cog(source=output, dst_path=output)
     except Exception as e:


### PR DESCRIPTION
**Overview:**
As a user of leafmap's `map_tiles_to_geotiff()` I would like to know what resolution (in m) the output `.tif` is when extracting using leafmap's interactive `zoom` functionality. 

**Changes:**
* Added functionality in `map_tiles_to_geotiff()` function to add both the `zoom` and the `resolution` into the metadata (tags) of the output `.tif`. 
* Added an inner function to `map_tiles_to_geotiff()`  called `zoom_level_to_resolution()` that calculates the resolution in m from the input zoom.

**Scenario Testing**
I have tested the possible function calls associated with `map_tiles_to_geotiff()` to ensure that added code doesn't break any existing workflows. 

1. `map_tiles_to_geotiff()` with `crs.upper() == "EPSG:3857"` to avoid running `reproject()` and `to_cog = False` to ensure only running inner function `draw_tile()`

Code Snippet (input):
```
# create a .tif file for the bbox.
image = "image.tif"
leafmap.map_tiles_to_geotiff(
    output=image,
    bbox=bbox,
    zoom=19,
    source="Satellite",
    overwrite=True,
    quiet=True,
    # crs="EPSG:4326",  # force reproject() function execution.
    to_cog=False
)

# check metadata tags.
import rasterio
with rasterio.open(image) as src:
    print(src.tags())
```

Output:
```
 {'AREA_OR_POINT': 'Area', 'RESOLUTION_M': '0.29858214173896974', 'ZOOM_LEVEL': '19'}
```


2. `map_tiles_to_geotiff()` with `crs.upper() != "EPSG:3857"` and `to_cog = False` to ensure both `draw_tile()` and `reproject()` are executed. 

Code Snippet (input):
```
# create a .tif file for the bbox.
image = "image.tif"
leafmap.map_tiles_to_geotiff(
    output=image,
    bbox=bbox,
    zoom=19,
    source="Satellite",
    overwrite=True,
    quiet=True,
    crs="EPSG:4326",  # force reproject() function execution.
    to_cog=False
)

# check metadata tags.
import rasterio
with rasterio.open(image) as src:
    print(src.tags())
```

Output
```
{'AREA_OR_POINT': 'Area', 'RESOLUTION_M': '0.29858214173896974', 'ZOOM_LEVEL': '19'}
```

3. `map_tiles_to_geotiff()` with `crs.upper() == "EPSG:3857"` and `to_cog = True` to ensure both `draw_tile()` and `image_to_cog()` are executed.

Code Snippet (input):
```
# create a .tif file for the bbox.
image = "image.tif"
leafmap.map_tiles_to_geotiff(
    output=image,
    bbox=bbox,
    zoom=19,
    source="Satellite",
    overwrite=True,
    quiet=True,
    # crs="EPSG:4326",  # force reproject() function execution.
    to_cog=True
)

# check metadata tags.
import rasterio
with rasterio.open(image) as src:
    print(src.tags())
```

Output
```
{'AREA_OR_POINT': 'Area', 'OVR_RESAMPLING_ALG': 'NEAREST', 'RESOLUTION_M': '0.29858214173896974', 'ZOOM_LEVEL': '19'}
```

4. `map_tiles_to_geotiff()` with `crs.upper() != "EPSG:3857"` and `to_cog = True` to ensure both `draw_tile()`, `reproject()` and `image_to_cog()` are executed. 

Code Snippet (input):

```
# create a .tif file for the bbox.
image = "image.tif"
leafmap.map_tiles_to_geotiff(
    output=image,
    bbox=bbox,
    zoom=19,
    source="Satellite",
    overwrite=True,
    quiet=True,
    crs="EPSG:4326",  # force reproject() function execution.
    to_cog=True
)

# check metadata tags.
import rasterio
with rasterio.open(image) as src:
    print(src.tags())
```

Output:
```
{'AREA_OR_POINT': 'Area', 'OVR_RESAMPLING_ALG': 'NEAREST', 'RESOLUTION_M': '0.29858214173896974', 'ZOOM_LEVEL': '19'}
```

