### PR TITLE
Update  add_raster() to avoid duplicate layer names being overwritten

### DIFF
--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -997,6 +997,7 @@ class Map(ipyleaflet.Map):
         titiler_endpoint=None,
         zoom_to_layer=True,
         layer_index=None,
+        overwrite=False,
         **kwargs,
     ) -> None:
         """Adds a COG TileLayer to the map.
@@ -1011,6 +1012,7 @@ class Map(ipyleaflet.Map):
             titiler_endpoint (str, optional): Titiler endpoint. Defaults to "https://titiler.xyz".
             zoom_to_layer (bool, optional): Whether to zoom to the layer extent. Defaults to True.
             layer_index (int, optional): The index at which to add the layer. Defaults to None.
+            overwrite (bool, optional): Whether to overwrite the layer if it already exists. Defaults to False.
             **kwargs: Arbitrary keyword arguments, including bidx, expression, nodata, unscale, resampling, rescale,
                 color_formula, colormap, colormap_name, return_mask. See https://developmentseed.org/titiler/endpoints/cog/
                 and https://cogeotiff.github.io/rio-tiler/colormap/. To select a certain bands, use bidx=[1, 2, 3].
@@ -1045,6 +1047,13 @@ class Map(ipyleaflet.Map):
 
         tile_url = common.cog_tile(url, bands, titiler_endpoint, **kwargs)
         bounds = common.cog_bounds(url, titiler_endpoint)
+
+        name = self._check_layer_name(name, overwrite=overwrite)
+        if overwrite and name in self.get_layer_names():
+            layer = self.find_layer(name)
+            if layer is not None:
+                self.remove_layer(layer)
+
         self.add_tile_layer(tile_url, name, attribution, opacity, shown, layer_index)
         if zoom_to_layer:
             self.fit_bounds([[bounds[1], bounds[0]], [bounds[3], bounds[2]]])
@@ -2349,6 +2358,33 @@ class Map(ipyleaflet.Map):
         for tool in toolbar_grid.children:
             tool.value = False
 
+    def _check_layer_name(self, layer_name: str, overwrite: bool = False) -> str:
+        """Checks and ensures the uniqueness of a layer name.
+
+        If the provided layer name already exists in the map, this function appends
+        a numeric suffix to make it unique unless `overwrite` is set to True.
+
+        Args:
+            layer_name (str): The name of the layer to check.
+            overwrite (bool, optional): Whether to overwrite an existing layer with the same name. Defaults to False.
+
+        Returns:
+            str: A unique layer name.
+        """
+        names = self.get_layer_names()
+        if layer_name in names:
+            if not overwrite:
+                base_name = layer_name
+                suffix = 1
+                while f"{base_name}_{suffix}" in names:
+                    suffix += 1
+                layer_name = f"{base_name}_{suffix}"
+                return layer_name
+            else:
+                return layer_name
+        else:
+            return layer_name
+
     def add_raster(
         self,
         source: str,
@@ -2365,6 +2401,7 @@ class Map(ipyleaflet.Map):
         opacity: Optional[float] = 1.0,
         array_args: Optional[Dict] = {},
         client_args: Optional[Dict] = {"cors_all": False},
+        overwrite: Optional[bool] = False,
         **kwargs,
     ) -> None:
         """Add a local raster dataset to the map.
@@ -2390,21 +2427,13 @@ class Map(ipyleaflet.Map):
             opacity (float, optional): The opacity of the layer. Defaults to 1.0.
             array_args (dict, optional): Additional arguments to pass to `array_to_memory_file` when reading the raster. Defaults to {}.
             client_args (dict, optional): Additional arguments to pass to localtileserver.TileClient. Defaults to { "cors_all": False }.
+            overwrite (bool, optional): Whether to overwrite an existing layer with the same name. Defaults to False.
         """
         import numpy as np
         import xarray as xr
 
         if isinstance(source, np.ndarray) or isinstance(source, xr.DataArray):
             source = common.array_to_image(source, **array_args)
-
-        # handle duplicate input layer names.
-        if hasattr(self, "cog_layer_dict"):
-            if layer_name in self.cog_layer_dict:
-                base_name = layer_name
-                suffix = 1
-                while f"{base_name}_{suffix}" in self.cog_layer_dict:
-                    suffix += 1
-                layer_name = f"{base_name}_{suffix}"
 
         tile_layer = common.get_local_tile_layer(
             source,
@@ -2422,6 +2451,12 @@ class Map(ipyleaflet.Map):
         )
         tile_layer.visible = visible
         tile_client = tile_layer.tile_server
+        tile_layer.name = self._check_layer_name(layer_name, overwrite=overwrite)
+
+        if overwrite and layer_name in self.get_layer_names():
+            layer = self.find_layer(tile_layer.name)
+            if layer is not None:
+                self.remove(layer)
 
         self.add(tile_layer, index=layer_index)
         if zoom_to_layer:
@@ -2431,7 +2466,7 @@ class Map(ipyleaflet.Map):
             except AttributeError:
                 self.zoom = 15
 
-        common.arc_add_layer(tile_layer.url, layer_name, True, 1.0)
+        common.arc_add_layer(tile_layer.url, tile_layer.name, True, 1.0)
 
         if not hasattr(self, "cog_layer_dict"):
             self.cog_layer_dict = {}
@@ -2455,11 +2490,11 @@ class Map(ipyleaflet.Map):
             "nodata": nodata,
             "colormap": colormap,
             "opacity": opacity,
-            "layer_name": layer_name,
+            "layer_name": tile_layer.name,
             "filename": tile_client.filename,
             "type": "LOCAL",
         }
-        self.cog_layer_dict[layer_name] = params
+        self.cog_layer_dict[tile_layer.name] = params
         self.tile_client = tile_client
 
     add_local_tile = add_raster

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -2397,6 +2397,15 @@ class Map(ipyleaflet.Map):
         if isinstance(source, np.ndarray) or isinstance(source, xr.DataArray):
             source = common.array_to_image(source, **array_args)
 
+        # handle duplicate input layer names.
+        if hasattr(self, "cog_layer_dict"):
+            if layer_name in self.cog_layer_dict:
+                base_name = layer_name
+                suffix = 1
+                while f"{base_name}_{suffix}" in self.cog_layer_dict:
+                    suffix += 1
+                layer_name = f"{base_name}_{suffix}"
+
         tile_layer = common.get_local_tile_layer(
             source,
             indexes=indexes,


### PR DESCRIPTION
**Changes:**

1. **Current behaviour:**
If a user adds N different rasters (from different source) to a map with the same `layer_name` arg the last raster added will overwrite the previous raster layers in the `m.cog_layer_dict` even though N rasters are displayed on the map.

2. **Expected behaviour:** 
If a user adds N different rasters (from different source) to a map with the same `layer_name`, subsequent rasters added after the 1st raster will have their `layer_name` appended with a suffix to make that `layer_name` unique. This will avoid any layers being overwritten in `m.cog_layer_dict`.

**Examples:**

Raw map, created using:

```
m = leafmap.Map(center=[-22.17615, -51.253043], zoom=19, height="450px")
m.add_basemap("SATELLITE")
m.layers[-1].visible = False
m.add_raster('image.tif', layer_name="image")
```

<img width="546" alt="raw_map" src="https://github.com/user-attachments/assets/d969147d-57f7-417a-8ead-938e149e4f11" />


1. **Existing behaviour**:

If we add a raster layer taking the default `layer_name` = "Raster" using:

```
m.add_raster(source="masks.tif",
             colormap="tab20",
             nodata=0,
             opacity=0.7) 
```

we get the following `m.cog_layer_dict.keys`:

```
dict_keys(['image', 'Raster'])
```

and the map looks like:
<img width="527" alt="raw_with_1_mask" src="https://github.com/user-attachments/assets/591a81fe-c114-49fa-9198-ff3812131472" />

If we add a second raster with the same `layer_name` using:

```
m.add_raster(source="masks_dtrees2.tif",
             colormap="tab20",
             nodata=0,
             opacity=0.7)
```

Currently, the `m.cog_layer_dict.keys` will be:

```
dict_keys(['image', 'Raster'])
```

**Even though both rasters are displayed on the image** (this is to do with how the `localtileserver` handles the tiles):

<img width="511" alt="raw_with_2_masks" src="https://github.com/user-attachments/assets/adfadc20-d1ce-4744-bea7-fe2249542d42" />

1. **New behaviour**:

After adding the two rasters with the same name, the `m.cog_layer_dict.keys` will be:

```
dict_keys(['image', 'Raster', 'Raster_1'])
```


**Changes:**

* added the following code snippet to `add_raster()`:

```
        # handle duplicate input layer names.
        if hasattr(self, "cog_layer_dict"):
            if layer_name in self.cog_layer_dict:
                base_name = layer_name
                suffix = 1
                while f"{base_name}_{suffix}" in self.cog_layer_dict:
                    suffix += 1
                layer_name = f"{base_name}_{suffix}"
```

The code simply runs a counter that adds an integer suffix to the `layer_name` until its unique.