### PR TITLE
Add use_message_queue to MapLibre Map

### DIFF
--- a/leafmap/maplibregl.py
+++ b/leafmap/maplibregl.py
@@ -74,6 +74,7 @@ class Map(MapWidget):
             "scale": "bottom-left",
         },
         projection: str = "mercator",
+        use_message_queue: bool = False,
         **kwargs: Any,
     ) -> None:
         """
@@ -98,6 +99,10 @@ class Map(MapWidget):
             height (str, optional): The height of the map. Defaults to "600px".
             controls (dict, optional): The controls and their positions on the
                 map. Defaults to {"fullscreen": "top-right", "scale": "bottom-left"}.
+            projection (str, optional): The projection of the map. It can be
+                "mercator" or "globe". Defaults to "mercator".
+            use_message_queue (bool, optional): Whether to use the message queue
+                for rendering the map. Defaults to False.
             **kwargs: Additional keyword arguments that are passed to the MapOptions class.
                 See https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/
                 for more information.
@@ -163,7 +168,8 @@ class Map(MapWidget):
         )
 
         super().__init__(map_options, height=height)
-        super().use_message_queue()
+        if use_message_queue:
+            super().use_message_queue()
 
         for control, position in controls.items():
             self.add_control(control, position)


### PR DESCRIPTION
Fix #1068. This allows the name to render multiple times without losing layers.

![image](https://github.com/user-attachments/assets/87508553-f1ee-4e9b-9cbb-124aab777b2a)
