### PR TITLE
Add spatial mosaic capability for OPERA products (TIFs only)

### DIFF
--- a/docs/notebooks/101_nasa_opera.ipynb
+++ b/docs/notebooks/101_nasa_opera.ipynb
@@ -75,7 +75,7 @@
    "source": [
     "Pan and zoom to your area of interest. Select a dataset from the Short Name dropdown list. Click the \"Search\" button to load the available datasets for the region. The footprints of the datasets will be displayed on the map. Click on a footprint to display the metadata of the dataset. \n",
     "\n",
-    "![image](https://github.com/user-attachments/assets/f3b1b42e-d83d-4f40-b9e6-67082d364367)"
+    "![image](https://github.com/user-attachments/assets/1fdb58b5-9faa-4666-96f3-0fb1869f7551)"
    ]
   },
   {
@@ -98,20 +98,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Select a dataset from the Dataset dropdown list. Then, select a layer from the Layer dropdown list. Choose a appropriate colormap, then click on the \"Display\" button to display the selected layer on the map."
+    "There are two options to visualize OPERA product granule(s):\n",
+    "\n",
+    "- Option 1: Select a dataset from the Dataset dropdown menu, and select a corresponding layer from the Layer dropdown menu. Choose a colormap (if colormap is blank, the default OPERA colormap from the metadata will be used). Click on the \"Display (Single)\" button to display the selected granule layer on the map.\n",
+    "\n",
+    "- Option 2: Select a layer from the Layer dropdown menu. Choose a colormap (if colormap is blank, the default OPERA colormap from the metadata will be used). Click on the \"Display (Mosaic)\" button to display a mosaic of the granules shown on the map (Currently only supported for geotiff products; RTC/DSWx/DIST)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The water classification layer:\n",
+    "The OPERA Dynamic Surface Water Extent from Sentinel-1 (DSWx-S1) water classification (WTR) layer over Lake Mead in southern Nevada, USA:\n",
     "\n",
-    "![image](https://github.com/user-attachments/assets/f9800913-c683-4a9f-a3b5-164c911a4486)\n",
+    "![image](https://github.com/user-attachments/assets/0ff253f3-e6b0-4bdd-8592-750b05414db8)\n",
     "\n",
-    "The DEM layer:\n",
+    "The OPERA Surface Disturbance from Harmonized Landsat and Sentinel-2 (DIST-HLS) vegetation disturbance status (VEG-DIST-STATUS) layer over a wildfire-impacted region of northern Quebec, Canada:\n",
     "\n",
-    "![image](https://github.com/user-attachments/assets/15690881-d259-474f-9c77-eb6c40027ccc)\n"
+    "![image](https://github.com/user-attachments/assets/fbb02210-8654-425b-84d3-620d12708e6a)\n"
    ]
   },
   {
@@ -143,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m._NASA_DATA_DS[\"band_data\"].rio.to_raster(\"DSWx.tif\")"
+    "m._NASA_DATA_DS.rio.to_raster(\"DSWx.tif\")"
    ]
   },
   {

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -6048,6 +6048,7 @@ def mosaic(
     if verbose:
         print(f"Saved mosaic to {output}")
 
+
 def mosaic_opera(DS, merge_args={}):
     """Mosaics a list of OPERA product granules into a single image (in memory).
 
@@ -6061,20 +6062,21 @@ def mosaic_opera(DS, merge_args={}):
         nodata: The nodata value for the mosaic corresponding to the original OPERA product granule metadata.
     """
     from rioxarray.merge import merge_arrays
-    
+
     DA = []
     for ds in DS:
         nodata = ds.rio.nodata
         da = ds.fillna(nodata)
         DA.append(da)
 
-    merged_arr =  merge_arrays(DA)
+    merged_arr = merge_arrays(DA)
 
     try:
         colormap = get_image_colormap(DS[0])
     except Exception as e:
         colormap = None
     return merged_arr, colormap, nodata
+
 
 def geometry_bounds(geometry, decimals=4):
     """Returns the bounds of a geometry.

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -6048,6 +6048,33 @@ def mosaic(
     if verbose:
         print(f"Saved mosaic to {output}")
 
+def mosaic_opera(DS, merge_args={}):
+    """Mosaics a list of OPERA product granules into a single image (in memory).
+
+    Args:
+        DS (list): A list of OPERA product granules opened as xarray.DataArray objects.
+        merge_args (dict, optional): A dictionary of arguments to pass to the rioxarray.merge_arrays function. Defaults to {}.
+
+    Returns:
+        da_mosaic: An xarray.DataArray containing the mosaic of the individual OPERA product granule DataArrays.
+        colormap: A colormap for the mosaic, if in the original OPERA metadata, otherwise None.
+        nodata: The nodata value for the mosaic corresponding to the original OPERA product granule metadata.
+    """
+    from rioxarray.merge import merge_arrays
+    
+    DA = []
+    for ds in DS:
+        nodata = ds.rio.nodata
+        da = ds.fillna(nodata)
+        DA.append(da)
+
+    merged_arr =  merge_arrays(DA)
+
+    try:
+        colormap = get_image_colormap(DS[0])
+    except Exception as e:
+        colormap = None
+    return merged_arr, colormap, nodata
 
 def geometry_bounds(geometry, decimals=4):
     """Returns the bounds of a geometry.

--- a/leafmap/toolbar.py
+++ b/leafmap/toolbar.py
@@ -6810,7 +6810,13 @@ def nasa_opera_gui(
     buttons = widgets.ToggleButtons(
         value=None,
         options=["Search", "Display (Single)", "Display (Mosaic)", "Reset", "Close"],
-        tooltips=["Get Items", "Display the Selected Granule", "Display Granule Mosaic", "Reset", "Close"],
+        tooltips=[
+            "Get Items",
+            "Display the Selected Granule",
+            "Display Granule Mosaic",
+            "Reset",
+            "Close",
+        ],
         button_style="primary",
     )
     buttons.style.button_width = "120px"
@@ -6919,7 +6925,7 @@ def nasa_opera_gui(
                             short_name=short_name.value,
                             bbox=bounds,
                             temporal=date_range,
-                            return_gdf=True
+                            return_gdf=True,
                         )
 
                         if len(results) > 0:
@@ -6940,7 +6946,7 @@ def nasa_opera_gui(
                                 "color": "#3388ff",
                                 "weight": 2,
                                 "opacity": 1,
-                                "fill": False
+                                "fill": False,
                             }
 
                             hover_style = {
@@ -6979,7 +6985,9 @@ def nasa_opera_gui(
 
                             if len(m._NASA_DATA_RESULTS) > 0:
                                 all_links = m._NASA_DATA_RESULTS[0].data_links()
-                                layer.options = [link.split("_")[-1] for link in all_links]
+                                layer.options = [
+                                    link.split("_")[-1] for link in all_links
+                                ]
                                 layer.value = layer.options[0]
                             else:
                                 layer.options = []
@@ -6987,9 +6995,13 @@ def nasa_opera_gui(
 
                             output.clear_output()
 
-                            print('Option 1: Select granule from the Dataset menu and click "Display (Single)"')
-                            print('Option 2: Click "Display (Mosaic)" to display a mosaic of all granules')
-                    
+                            print(
+                                'Option 1: Select granule from the Dataset menu and click "Display (Single)"'
+                            )
+                            print(
+                                'Option 2: Click "Display (Mosaic)" to display a mosaic of all granules'
+                            )
+
                     except Exception as e:
                         print(e)
 
@@ -7014,7 +7026,7 @@ def nasa_opera_gui(
                             f = open_file(
                                 link,
                                 earthdata_username=username,
-                                earthdata_password=password
+                                earthdata_password=password,
                             )
                             ds = rioxarray.open_rasterio(f, masked=False)
                         setattr(m, "_NASA_DATA_DS", ds)
@@ -7084,7 +7096,9 @@ def nasa_opera_gui(
             output.clear_output()
             with output:
                 print("Loading granule mosaic...")
-                layer_links = [result.data_links()[layer.index] for result in m._NASA_DATA_RESULTS]
+                layer_links = [
+                    result.data_links()[layer.index] for result in m._NASA_DATA_RESULTS
+                ]
                 tif_links = [link for link in layer_links if link.endswith(".tif")]
                 if tif_links:
                     links = tif_links
@@ -7100,7 +7114,7 @@ def nasa_opera_gui(
                                 f = open_file(
                                     link,
                                     earthdata_username=username,
-                                    earthdata_password=password
+                                    earthdata_password=password,
                                 )
                                 DS.append(rioxarray.open_rasterio(f, masked=False))
                         da_mosaic, colormap, nodata = mosaic_opera(DS, merge_args={})
@@ -7124,7 +7138,7 @@ def nasa_opera_gui(
                         print("Currently only geotiff mosaicking is supported.")
                 except Exception as e:
                     output.clear_output()
-                    print(e)            
+                    print(e)
 
         elif change["new"] == "Reset":
             short_name.options = m._NASA_DATA_NAMES


### PR DESCRIPTION
This PR adds functionality for constructing and visualizing a spatial mosaic of OPERA product granules, while retaining the ability to view/download a single product granule. Mosaicking functionality is currently only supported for OPERA products in geotiff format (RTC/DSWx/DIST).

*Specific updates:*
- Add `opera_mosaic()` function to `common.py` to enable spatial mosaicking of individual OPERA granules (xarray.DataArray objects) into a single xarray.DataArray object.
- Reformat `nasa_opera_gui` widget in `toolbar.py` to replace `Display` button with `Display (Single)` and `Display (Mosaic)` buttons, and add new logic to enable single and mosaic visualization using `opera_mosaic().
- Update `101_nasa_opera.ipynb` to accommodate mosaicking and provide example outputs.
<img width="1242" alt="opera-gui_search" src="https://github.com/user-attachments/assets/1fdb58b5-9faa-4666-96f3-0fb1869f7551" />
<img width="1244" alt="opera_DSWx-S1_leafmap_mosaic" src="https://github.com/user-attachments/assets/e947b4ae-1d0a-4dd2-96f7-c649888a4944" />
<img width="1341" alt="opera-gui_DSWx-S1" src="https://github.com/user-attachments/assets/0ff253f3-e6b0-4bdd-8592-750b05414db8" />
<img width="1324" alt="opera_DIST-HLS_leafmap_mosaic" src="https://github.com/user-attachments/assets/fc8fe96b-6fa9-41ef-a14a-7ce9e932aeeb" />
<img width="1343" alt="opera-gui_DIST-HLS" src="https://github.com/user-attachments/assets/fbb02210-8654-425b-84d3-620d12708e6a" />