### PR TITLE
Fix folium draw control bug

### DIFF
--- a/leafmap/foliumap.py
+++ b/leafmap/foliumap.py
@@ -169,9 +169,9 @@ class Map(folium.Map):
             plugins.Fullscreen().add_to(self)
 
         if "draw_control" not in kwargs:
-            kwargs["draw_control"] = False
+            kwargs["draw_control"] = True
         if kwargs["draw_control"]:
-            plugins.Draw(export=kwargs.get("draw_export")).add_to(self)
+            plugins.Draw(export=kwargs.pop("draw_export")).add_to(self)
 
         if "measure_control" not in kwargs:
             kwargs["measure_control"] = False


### PR DESCRIPTION
Fix #1149 

To show the draw control with the export button:
```python
import leafmap.foliumap as leafmap

m = leafmap.Map(draw_export=True)
m
```

To hide the draw control
```python
m = leafmap.Map(draw_control=False)
m
```