### PR TITLE
Add support for AlphaEarth satellite embeddings

### DIFF
--- a/docs/maplibre/overview.md
+++ b/docs/maplibre/overview.md
@@ -128,6 +128,12 @@ Add text to the map.
 
 [![](https://i.imgur.com/UAtlh3r.png)](https://leafmap.org/maplibre/add_text)
 
+## Visualize AlphaEarth satellite embeddings in 3D
+
+Visualize AlphaEarth satellite embeddings in 3D.
+
+[![](https://github.com/user-attachments/assets/fdcf844e-6385-4e62-a49f-363c00fa0998)](https://leafmap.org/maplibre/AlphaEarth)
+
 ## Animate a line
 
 Animate a line by updating a GeoJSON source on each frame.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ plugins:
                   "maplibre/mapillary.ipynb",
                   "maplibre/nasa_opera.ipynb",
                   "maplibre/live_update_feature.ipynb",
+                  "maplibre/AlphaEarth.ipynb",
               ]
 
 markdown_extensions:
@@ -189,6 +190,7 @@ nav:
           - maplibre/add_legend.ipynb
           - maplibre/add_logo.ipynb
           - maplibre/add_text.ipynb
+          - maplibre/AlphaEarth.ipynb
           - maplibre/animate_a_line.ipynb
           - maplibre/animate_camera_around_point.ipynb
           - maplibre/animate_images.ipynb


### PR DESCRIPTION
```python
import leafmap.maplibregl as leafmap

m = leafmap.Map(projection="globe", sidebar_visible=True)
m.add_basemap("USGS.Imagery")
m.add_alphaearth_gui()
m
```

<img width="1335" height="717" alt="image" src="https://github.com/user-attachments/assets/fdcf844e-6385-4e62-a49f-363c00fa0998" />
