### PR TITLE
Allow loading styles via http in addition to https

### DIFF
--- a/leafmap/maplibregl.py
+++ b/leafmap/maplibregl.py
@@ -150,7 +150,7 @@ class Map(MapWidget):
         ]
         if isinstance(style, str):
 
-            if style.startswith("https"):
+            if style.startswith("http"):
                 response = requests.get(style)
                 if response.status_code != 200:
                     print(


### PR DESCRIPTION
Relax style URL restrictions to support both http and https. 

This is especially useful for local development setups, e.g. running a localhost server for serving styles over http.