### PR TITLE
fix maplibre examples broken links (#1222)

### DIFF
--- a/docs/maplibre/3d_buildings.ipynb
+++ b/docs/maplibre/3d_buildings.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Display buildings in 3D**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Display buildings in 3D](https://maplibre.org/maplibre-gl-js/docs/examples/3d-buildings/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Display buildings in 3D](https://maplibre.org/maplibre-gl-js/docs/examples/display-buildings-in-3d/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/3d_indoor_mapping.ipynb
+++ b/docs/maplibre/3d_indoor_mapping.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Extrude polygons for 3D indoor mapping**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Extrude polygons for 3D indoor mapping](https://maplibre.org/maplibre-gl-js/docs/examples/3d-extrusion-floorplan/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Extrude polygons for 3D indoor mapping](https://maplibre.org/maplibre-gl-js/docs/examples/extrude-polygons-for-3d-indoor-mapping/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/add_a_marker.ipynb
+++ b/docs/maplibre/add_a_marker.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a default marker**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a default marker](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-marker/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a default marker](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-default-marker/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/add_deckgl_layer.ipynb
+++ b/docs/maplibre/add_deckgl_layer.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add deck.gl layers**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Create deck.gl layer using REST API](https://maplibre.org/maplibre-gl-js/docs/examples/add-deckgl-layer-using-rest-api/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Create deck.gl layer using REST API](https://maplibre.org/maplibre-gl-js/docs/examples/create-deckgl-layer-using-rest-api/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/add_image.ipynb
+++ b/docs/maplibre/add_image.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add an icon to the map**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add an icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/add-image/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add an icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/add-an-icon-to-the-map/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/add_image_generated.ipynb
+++ b/docs/maplibre/add_image_generated.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a generated icon to the map**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a generated icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/add-image-generated/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a generated icon to the map](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-generated-icon-to-the-map/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/animate_images.ipynb
+++ b/docs/maplibre/animate_images.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Animate a series of images**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Animate a series of images](https://maplibre.org/maplibre-gl-js/docs/examples/animate-images/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Animate a series of images](https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-series-of-images/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/animate_point_along_line.ipynb
+++ b/docs/maplibre/animate_point_along_line.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Animate a point**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Animate a point](https://maplibre.org/maplibre-gl-js/docs/examples/animate-point-along-line/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Animate a point](https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/animate_point_along_route.ipynb
+++ b/docs/maplibre/animate_point_along_route.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Animate a point along a route**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Animate a point along a route](https://maplibre.org/maplibre-gl-js/docs/examples/animate-point-along-route/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Animate a point along a route](https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point-along-a-route/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/attribution_position.ipynb
+++ b/docs/maplibre/attribution_position.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Change the default position for attribution**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Change the default position for attribution](https://maplibre.org/maplibre-gl-js/docs/examples/attribution-position/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Change the default position for attribution](https://maplibre.org/maplibre-gl-js/docs/examples/change-the-default-position-for-attribution/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/center_on_symbol.ipynb
+++ b/docs/maplibre/center_on_symbol.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Center the map on a clicked symbol**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Center the map on a clicked symbol](https://maplibre.org/maplibre-gl-js/docs/examples/center-on-symbol/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Center the map on a clicked symbol](https://maplibre.org/maplibre-gl-js/docs/examples/center-the-map-on-a-clicked-symbol/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/change_case_of_labels.ipynb
+++ b/docs/maplibre/change_case_of_labels.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Change the case of labels**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-case-of-labels/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Change the case of labels](https://maplibre.org/maplibre-gl-js/docs/examples/change-the-case-of-labels/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/cluster.ipynb
+++ b/docs/maplibre/cluster.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Create and style clusters**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/cluster/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Create and style clusters](https://maplibre.org/maplibre-gl-js/docs/examples/create-and-style-clusters/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/color_switcher.ipynb
+++ b/docs/maplibre/color_switcher.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Change a layer's color with buttons**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Change a layer's color with buttons](https://maplibre.org/maplibre-gl-js/docs/examples/color-switcher/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Change a layer's color with buttons](https://maplibre.org/maplibre-gl-js/docs/examples/change-a-layers-color-with-buttons/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/data_driven_lines.ipynb
+++ b/docs/maplibre/data_driven_lines.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Style lines with a data-driven property**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Style lines with a data-driven property](https://maplibre.org/maplibre-gl-js/docs/examples/data-driven-lines/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Style lines with a data-driven property](https://maplibre.org/maplibre-gl-js/docs/examples/style-lines-with-a-data-driven-property/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/drag_a_marker.ipynb
+++ b/docs/maplibre/drag_a_marker.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Create a draggable Marker**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Create a draggable Marker](https://maplibre.org/maplibre-gl-js/docs/examples/drag-a-marker/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Create a draggable Marker](https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-marker/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/fallback_image.ipynb
+++ b/docs/maplibre/fallback_image.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Use a fallback image**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/fallback-image/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Use a fallback image](https://maplibre.org/maplibre-gl-js/docs/examples/use-a-fallback-image/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/fill_pattern.ipynb
+++ b/docs/maplibre/fill_pattern.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a pattern to a polygon**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a pattern to a polygon](https://maplibre.org/maplibre-gl-js/docs/examples/fill-pattern/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a pattern to a polygon](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-pattern-to-a-polygon/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/fit_bounds.ipynb
+++ b/docs/maplibre/fit_bounds.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Fit a map to a bounding box**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Fit a map to a bounding box](https://maplibre.org/maplibre-gl-js/docs/examples/fitbounds/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Fit a map to a bounding box](https://maplibre.org/maplibre-gl-js/docs/examples/fit-a-map-to-a-bounding-box/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/fly_to.ipynb
+++ b/docs/maplibre/fly_to.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Fly to a location**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Fly to a location](https://maplibre.org/maplibre-gl-js/docs/examples/flyto/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Fly to a location](https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/fly_to_options.ipynb
+++ b/docs/maplibre/fly_to_options.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Slowly fly to a location**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Slowly fly to a location](https://maplibre.org/maplibre-gl-js/docs/examples/flyto-options/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Slowly fly to a location](https://maplibre.org/maplibre-gl-js/docs/examples/slowly-fly-to-a-location/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/fullscreen.ipynb
+++ b/docs/maplibre/fullscreen.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**View a fullscreen map**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [View a fullscreen map](https://maplibre.org/maplibre-gl-js/docs/examples/fullscreen/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [View a fullscreen map](https://maplibre.org/maplibre-gl-js/docs/examples/view-a-fullscreen-map/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/geojson_layer_in_stack.ipynb
+++ b/docs/maplibre/geojson_layer_in_stack.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a new layer below labels**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a new layer below labels](https://maplibre.org/maplibre-gl-js/docs/examples/geojson-layer-in-stack/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a new layer below labels](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-new-layer-below-labels/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/geojson_line.ipynb
+++ b/docs/maplibre/geojson_line.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a GeoJSON line**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a GeoJSON line](https://maplibre.org/maplibre-gl-js/docs/examples/geojson-line/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a GeoJSON line](https://maplibre.org/maplibre-gl-js/docs/examples/#add-a-geojson-line).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/geojson_points.ipynb
+++ b/docs/maplibre/geojson_points.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Draw points from a GeoJSON collection to a map.\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Draw GeoJSON points](https://maplibre.org/maplibre-gl-js/docs/examples/geojson-markers).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Draw GeoJSON points](https://maplibre.org/maplibre-gl-js/docs/examples/draw-geojson-points/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/geojson_polygon.ipynb
+++ b/docs/maplibre/geojson_polygon.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a GeoJSON polygon**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a GeoJSON polygon](https://maplibre.org/maplibre-gl-js/docs/examples/geojson-polygon/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a GeoJSON polygon](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-polygon/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/heatmap_layer.ipynb
+++ b/docs/maplibre/heatmap_layer.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Create a heatmap layer**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Create a heatmap layer](https://maplibre.org/maplibre-gl-js/docs/examples/heatmap-layer/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Create a heatmap layer](https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/interactive_false.ipynb
+++ b/docs/maplibre/interactive_false.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Display a non-interactive map**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Display a non-interactive map](https://maplibre.org/maplibre-gl-js/docs/examples/interactive-false/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Display a non-interactive map](https://maplibre.org/maplibre-gl-js/docs/examples/display-a-non-interactive-map/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/jump_to.ipynb
+++ b/docs/maplibre/jump_to.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Jump to a series of locations**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Jump to a series of locations](https://maplibre.org/maplibre-gl-js/docs/examples/jump-to/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Jump to a series of locations](https://maplibre.org/maplibre-gl-js/docs/examples/jump-to-a-series-of-locations/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/language_switch.ipynb
+++ b/docs/maplibre/language_switch.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Change a map's language**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Change a map's language](https://maplibre.org/maplibre-gl-js/docs/examples/language-switch/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Change a map's language](https://maplibre.org/maplibre-gl-js/docs/examples/change-a-maps-language/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/line_gradient.ipynb
+++ b/docs/maplibre/line_gradient.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Use the line-gradient paint property and an expression to visualize distance from the starting point of a line.\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Create a gradient line using an expression](https://maplibre.org/maplibre-gl-js/docs/examples/line-gradient/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Create a gradient line using an expression](https://maplibre.org/maplibre-gl-js/docs/examples/create-a-gradient-line-using-an-expression/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/live_geojson.ipynb
+++ b/docs/maplibre/live_geojson.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Use realtime GeoJSON data streams to move a symbol on your map.\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add live realtime data](https://maplibre.org/maplibre-gl-js/docs/examples/live-geojson/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add live realtime data](https://maplibre.org/maplibre-gl-js/docs/examples/add-live-realtime-data/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/live_update_feature.ipynb
+++ b/docs/maplibre/live_update_feature.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Change an existing feature on your map in real-time by updating its data.\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Update a feature in realtime](https://maplibre.org/maplibre-gl-js/docs/examples/live-update-feature/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Update a feature in realtime](https://maplibre.org/maplibre-gl-js/docs/examples/update-a-feature-in-realtime/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/local_geojson.ipynb
+++ b/docs/maplibre/local_geojson.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**View local GeoJSON**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [View local GeoJSON](https://maplibre.org/maplibre-gl-js/docs/examples/local-geojson/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [View local GeoJSON](https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/locate_user.ipynb
+++ b/docs/maplibre/locate_user.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Locate the user**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Locate the user](https://maplibre.org/maplibre-gl-js/docs/examples/locate-user/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Locate the user](https://maplibre.org/maplibre-gl-js/docs/examples/locate-the-user/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/map_tiles.ipynb
+++ b/docs/maplibre/map_tiles.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a raster tile source**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a raster tile source](https://maplibre.org/maplibre-gl-js/docs/examples/map-tiles/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a raster tile source](https://maplibre.org/maplibre-gl-js/docs/examples/#add-a-raster-tile-source).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/mouse_position.ipynb
+++ b/docs/maplibre/mouse_position.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Get coordinates of the mouse pointer**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Get coordinates of the mouse pointer](https://maplibre.org/maplibre-gl-js/docs/examples/mouse-position/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Get coordinates of the mouse pointer](https://maplibre.org/maplibre-gl-js/docs/examples/get-coordinates-of-the-mouse-pointer/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/multiple_geometries.ipynb
+++ b/docs/maplibre/multiple_geometries.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add multiple geometries from one GeoJSON source**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add multiple geometries from one GeoJSON source](https://maplibre.org/maplibre-gl-js/docs/examples/multiple-geometries/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add multiple geometries from one GeoJSON source](https://maplibre.org/maplibre-gl-js/docs/examples/add-multiple-geometries-from-one-geojson-source/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/navigation.ipynb
+++ b/docs/maplibre/navigation.ipynb
@@ -8,9 +8,9 @@
     "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/docs/maplibre/navigation.ipynb)\n",
     "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/opengeos/leafmap/HEAD)\n",
     "\n",
-    "**VDisplay map navigation controls**\n",
+    "**Display map navigation controls**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Display map navigation controls](https://maplibre.org/maplibre-gl-js/docs/examples/navigation/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Display map navigation controls](https://maplibre.org/maplibre-gl-js/docs/examples/display-map-navigation-controls/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/pmtiles.ipynb
+++ b/docs/maplibre/pmtiles.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "**PMTiles source and protocol**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [mPMTiles source and protocol](https://maplibre.org/maplibre-gl-js/docs/examples/pmtiles/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [PMTiles source and protocol](https://maplibre.org/maplibre-gl-js/docs/examples/pmtiles-source-and-protocol/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/restrict_bounds.ipynb
+++ b/docs/maplibre/restrict_bounds.ipynb
@@ -11,7 +11,7 @@
     "**Restrict map panning to an area**\n",
     "\n",
     "This source code of this example is adapted from the MapLibre GL JS example - [Restrict map panning to an area\n",
-    "](https://maplibre.org/maplibre-gl-js/docs/examples/restrict-bounds/).\n",
+    "](https://maplibre.org/maplibre-gl-js/docs/examples/restrict-map-panning-to-an-area/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/satellite_map.ipynb
+++ b/docs/maplibre/satellite_map.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Display a satellite map**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Display a satellite map](https://maplibre.org/maplibre-gl-js/docs/examples/satellite-map/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Display a satellite map](https://maplibre.org/maplibre-gl-js/docs/examples/display-a-satellite-map/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/set_pitch_bearing.ipynb
+++ b/docs/maplibre/set_pitch_bearing.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Set pitch and bearing**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Set pitch and bearing](https://maplibre.org/maplibre-gl-js/docs/examples/set-perspective/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Set pitch and bearing](https://maplibre.org/maplibre-gl-js/docs/examples/set-pitch-and-bearing/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/variable_offset_label_placement.ipynb
+++ b/docs/maplibre/variable_offset_label_placement.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Variable label placement with offset**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Variable label placement with offset](https://maplibre.org/maplibre-gl-js/docs/examples/variable-offset-label-placement/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Variable label placement with offset](https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement-with-offset/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/vector_tile.ipynb
+++ b/docs/maplibre/vector_tile.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a vector tile source**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a vector tile source](https://maplibre.org/maplibre-gl-js/docs/examples/vector-source/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a vector tile source](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-vector-tile-source/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/video_on_a_map.ipynb
+++ b/docs/maplibre/video_on_a_map.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a video**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a video](https://maplibre.org/maplibre-gl-js/docs/examples/video-on-a-map/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a video](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-video/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/wms_source.ipynb
+++ b/docs/maplibre/wms_source.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Add a WMS source**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Add a WMS source](https://maplibre.org/maplibre-gl-js/docs/examples/wms/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Add a WMS source](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-wms-source/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]

--- a/docs/maplibre/zoom_to_linestring.ipynb
+++ b/docs/maplibre/zoom_to_linestring.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "**Fit to the bounds of a LineString**\n",
     "\n",
-    "This source code of this example is adapted from the MapLibre GL JS example - [Fit to the bounds of a LineString](https://maplibre.org/maplibre-gl-js/docs/examples/zoomto-linestring/).\n",
+    "This source code of this example is adapted from the MapLibre GL JS example - [Fit to the bounds of a LineString](https://maplibre.org/maplibre-gl-js/docs/examples/fit-to-the-bounds-of-a-linestring/).\n",
     "\n",
     "Uncomment the following line to install [leafmap](https://leafmap.org) if needed."
    ]


### PR DESCRIPTION
the unchanged examples are either correct or have missing examples in maplibre like this one https://leafmap.org/maplibre/add_colorbar/