### PR TITLE
chore(refactor): parameter bands value 'None' instead can use str

### DIFF
--- a/leafmap/stac.py
+++ b/leafmap/stac.py
@@ -134,7 +134,7 @@ def check_titiler_endpoint(titiler_endpoint: Optional[str] = None) -> Any:
 
 def cog_tile(
     url,
-    bands: Optional[str | None] = None,
+    bands: Optional[str] = None,
     titiler_endpoint: Optional[str] = None,
     **kwargs,
 ) -> Tuple:


### PR DESCRIPTION
reference that from parameters from function `cog_title` which is 
```
url (str): HTTP URL to a COG, e.g.,
https://opendata.digitalglobe.com/events/mauritius-oil-spill/post-event/2020-08-12/105001001F1B5B00/105001001F1B5B00.tif.
``` 
default value set to be `None`