### PR TITLE
Add QuackOSM support for high-performance OSM data download

### DIFF
--- a/docs/notebooks/107_quackosm.ipynb
+++ b/docs/notebooks/107_quackosm.ipynb
@@ -165,8 +165,7 @@
    "source": [
     "# Download restaurants and cafes\n",
     "dining = osm.quackosm_gdf_from_place(\n",
-    "    \"Monaco\", \n",
-    "    tags={\"amenity\": [\"restaurant\", \"cafe\", \"bar\"]}\n",
+    "    \"Monaco\", tags={\"amenity\": [\"restaurant\", \"cafe\", \"bar\"]}\n",
     ")\n",
     "print(f\"Downloaded {len(dining)} dining establishments\")\n",
     "dining.head()"
@@ -249,7 +248,11 @@
    "outputs": [],
    "source": [
     "m = leafmap.Map(center=[41.905, 12.4525], zoom=16)\n",
-    "m.add_gdf(buildings_bbox, layer_name=\"Buildings\", style={\"color\": \"orange\", \"fillOpacity\": 0.5})\n",
+    "m.add_gdf(\n",
+    "    buildings_bbox,\n",
+    "    layer_name=\"Buildings\",\n",
+    "    style={\"color\": \"orange\", \"fillOpacity\": 0.5},\n",
+    ")\n",
     "m"
    ]
   },
@@ -273,13 +276,7 @@
     "from shapely.geometry import Polygon\n",
     "\n",
     "# Create a custom polygon\n",
-    "coords = [\n",
-    "    (7.41, 43.73),\n",
-    "    (7.43, 43.73),\n",
-    "    (7.43, 43.75),\n",
-    "    (7.41, 43.75),\n",
-    "    (7.41, 43.73)\n",
-    "]\n",
+    "coords = [(7.41, 43.73), (7.43, 43.73), (7.43, 43.75), (7.41, 43.75), (7.41, 43.73)]\n",
     "polygon = Polygon(coords)\n",
     "\n",
     "# Download natural features\n",
@@ -296,7 +293,9 @@
    "outputs": [],
    "source": [
     "m = leafmap.Map(center=[43.74, 7.42], zoom=14)\n",
-    "m.add_gdf(natural, layer_name=\"Natural Features\", style={\"color\": \"green\", \"fillOpacity\": 0.4})\n",
+    "m.add_gdf(\n",
+    "    natural, layer_name=\"Natural Features\", style={\"color\": \"green\", \"fillOpacity\": 0.4}\n",
+    ")\n",
     "m"
    ]
   },
@@ -371,7 +370,11 @@
     "\n",
     "# Add layers with different styles\n",
     "if len(buildings) > 0:\n",
-    "    m.add_gdf(buildings, layer_name=\"Buildings\", style={\"color\": \"red\", \"fillOpacity\": 0.3, \"weight\": 1})\n",
+    "    m.add_gdf(\n",
+    "        buildings,\n",
+    "        layer_name=\"Buildings\",\n",
+    "        style={\"color\": \"red\", \"fillOpacity\": 0.3, \"weight\": 1},\n",
+    "    )\n",
     "if len(roads) > 0:\n",
     "    m.add_gdf(roads, layer_name=\"Roads\", style={\"color\": \"gray\", \"weight\": 2})\n",
     "if len(water) > 0:\n",
@@ -400,8 +403,8 @@
    "source": [
     "# Export Monaco buildings to GeoParquet\n",
     "# output_path = osm.quackosm_to_parquet(\n",
-    "#     \"Monaco\", \n",
-    "#     \"monaco_buildings.parquet\", \n",
+    "#     \"Monaco\",\n",
+    "#     \"monaco_buildings.parquet\",\n",
     "#     tags={\"building\": True}\n",
     "# )\n",
     "# print(f\"Saved to: {output_path}\")"

--- a/leafmap/osm.py
+++ b/leafmap/osm.py
@@ -520,7 +520,9 @@ def quackosm_gdf_from_place(
 
     # Try using osm_extract_source first if specified
     if osm_extract_source:
-        source = getattr(OsmExtractSource, osm_extract_source.upper(), osm_extract_source)
+        source = getattr(
+            OsmExtractSource, osm_extract_source.upper(), osm_extract_source
+        )
         gdf = qosm.convert_osm_extract_to_geodataframe(
             query, osm_extract_source=source, tags_filter=tags_filter, **kwargs
         )
@@ -727,9 +729,7 @@ def quackosm_gdf_from_pbf(
     if geometry is not None:
         kwargs["geometry_filter"] = geometry
 
-    gdf = qosm.convert_pbf_to_geodataframe(
-        pbf_path, tags_filter=tags_filter, **kwargs
-    )
+    gdf = qosm.convert_pbf_to_geodataframe(pbf_path, tags_filter=tags_filter, **kwargs)
 
     return gdf
 
@@ -829,7 +829,10 @@ def quackosm_to_parquet(
         except Exception:
             geometry = qosm.geocode_to_geometry(source)
             parquet_path = qosm.convert_geometry_to_parquet(
-                geometry, result_file_path=output_path, tags_filter=tags_filter, **kwargs
+                geometry,
+                result_file_path=output_path,
+                tags_filter=tags_filter,
+                **kwargs,
             )
     elif isinstance(source, (tuple, list)) and len(source) == 4:
         # Bounding box


### PR DESCRIPTION
- Add quackosm_gdf_from_place() for downloading OSM data by place name
- Add quackosm_gdf_from_bbox() for downloading OSM data by bounding box
- Add quackosm_gdf_from_geometry() for downloading OSM data by geometry
- Add quackosm_gdf_from_pbf() for loading local PBF files
- Add quackosm_to_parquet() for exporting to GeoParquet format
- Add helper function _convert_tags_to_quackosm_filter()
- Create notebook example (107_quackosm.ipynb) demonstrating usage

Closes #1144