### PR TITLE
Fix split_map gray background when using vector layers

### DIFF
--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -2151,6 +2151,29 @@ class Map(ipyleaflet.Map):
                 raise ValueError(
                     f"right_layer must be one of the following: {', '.join(basemaps.keys())} or a string url to a tif file."
                 )
+            if isinstance(left_layer, ipyleaflet.GeoJSON) and isinstance(
+                right_layer, ipyleaflet.TileLayer
+            ):
+                bg = ipyleaflet.TileLayer(
+                    url=right_layer.url,
+                    name=right_layer.name,
+                    attribution=right_layer.attribution,
+                    max_zoom=right_layer.max_zoom,
+                )
+                left_layer = [bg, left_layer]
+
+            if isinstance(right_layer, ipyleaflet.GeoJSON) and isinstance(
+                left_layer, (ipyleaflet.TileLayer, list)
+            ):
+                source = left_layer[0] if isinstance(left_layer, list) else left_layer
+                bg = ipyleaflet.TileLayer(
+                    url=source.url,
+                    name=source.name,
+                    attribution=source.attribution,
+                    max_zoom=source.max_zoom,
+                )
+                right_layer = [bg, right_layer]
+
             control = ipyleaflet.SplitMapControl(
                 left_layer=left_layer, right_layer=right_layer
             )
@@ -7515,6 +7538,29 @@ def split_map(
             raise ValueError(
                 f"right_layer must be one of the following: {', '.join(basemaps.keys())} or a string url to a tif file."
             )
+        if isinstance(left_layer, ipyleaflet.GeoJSON) and isinstance(
+            right_layer, ipyleaflet.TileLayer
+        ):
+            bg = ipyleaflet.TileLayer(
+                url=right_layer.url,
+                name=right_layer.name,
+                attribution=right_layer.attribution,
+                max_zoom=right_layer.max_zoom,
+            )
+            left_layer = [bg, left_layer]
+
+        if isinstance(right_layer, ipyleaflet.GeoJSON) and isinstance(
+            left_layer, (ipyleaflet.TileLayer, list)
+        ):
+            source = left_layer[0] if isinstance(left_layer, list) else left_layer
+            bg = ipyleaflet.TileLayer(
+                url=source.url,
+                name=source.name,
+                attribution=source.attribution,
+                max_zoom=source.max_zoom,
+            )
+            right_layer = [bg, right_layer]
+
         control = ipyleaflet.SplitMapControl(
             left_layer=left_layer, right_layer=right_layer
         )


### PR DESCRIPTION
## Summary
- When using `split_map` with a GeoJSON/vector layer on one side and a raster (TIF) on the other, dragging the swipe divider showed a gray background behind the vector layer
- This fix duplicates the raster TileLayer from the opposite side as a background for the vector side, so the GeoJSON is always overlaid on the raster imagery
- Applied to both the `Map.split_map()` method and the module-level `split_map()` function

## Test plan
- [ ] Run `split_map` with a GeoJSON on the left and a raster on the right, drag the swipe divider and verify the vector layer shows the raster underneath instead of a gray background
- [ ] Run `split_map` with two raster layers to verify no regression
- [ ] Run `split_map` with a GeoDataFrame input to verify it also gets the raster background