### PR TITLE
Allow localtileserver prefix override and fix inferred prefix on JH

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -3316,21 +3316,23 @@ def get_local_tile_layer(
     for key in client_args:
         kwargs[key] = client_args[key]
 
-    # Make it compatible with binder and JupyterHub
-    if os.environ.get("JUPYTERHUB_SERVICE_PREFIX") is not None:
-        os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = (
-            f"{os.environ['JUPYTERHUB_SERVICE_PREFIX'].lstrip('/')}/proxy/{{port}}"
-        )
-
-    if is_studio_lab():
-        os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = (
-            f"studiolab/default/jupyter/proxy/{{port}}"
-        )
-    elif is_on_aws():
-        os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = "proxy/{port}"
-    elif "prefix" in kwargs:
-        os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = kwargs["prefix"]
-        kwargs.pop("prefix")
+    # Only override LOCALTILESERVER_CLIENT_PREFIX if it's unset
+    if os.environ.get("LOCALTILESERVER_CLIENT_PREFIX") is None:
+        # Make it compatible with binder and JupyterHub
+        if os.environ.get("JUPYTERHUB_SERVICE_PREFIX") is not None:
+            os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = (
+                f"{os.environ['JUPYTERHUB_SERVICE_PREFIX'].lstrip('/')}proxy/{{port}}"
+            )
+    
+        if is_studio_lab():
+            os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = (
+                f"studiolab/default/jupyter/proxy/{{port}}"
+            )
+        elif is_on_aws():
+            os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = "proxy/{port}"
+        elif "prefix" in kwargs:
+            os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = kwargs["prefix"]
+            kwargs.pop("prefix")
 
     from localtileserver import (
         TileClient,

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -3323,7 +3323,7 @@ def get_local_tile_layer(
             os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = (
                 f"{os.environ['JUPYTERHUB_SERVICE_PREFIX'].lstrip('/')}proxy/{{port}}"
             )
-    
+
         if is_studio_lab():
             os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = (
                 f"studiolab/default/jupyter/proxy/{{port}}"

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -3321,7 +3321,7 @@ def get_local_tile_layer(
         # Make it compatible with binder and JupyterHub
         if os.environ.get("JUPYTERHUB_SERVICE_PREFIX") is not None:
             os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = (
-                f"{os.environ['JUPYTERHUB_SERVICE_PREFIX'].lstrip('/')}proxy/{{port}}"
+                f"{os.environ['JUPYTERHUB_SERVICE_PREFIX'].strip('/')}/proxy/{{port}}"
             )
 
         if is_studio_lab():
@@ -3330,9 +3330,11 @@ def get_local_tile_layer(
             )
         elif is_on_aws():
             os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = "proxy/{port}"
-        elif "prefix" in kwargs:
-            os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = kwargs["prefix"]
-            kwargs.pop("prefix")
+
+    # The prefix kwarg has final precedence
+    if "prefix" in kwargs:
+        os.environ["LOCALTILESERVER_CLIENT_PREFIX"] = kwargs["prefix"]
+        kwargs.pop("prefix")
 
     from localtileserver import (
         TileClient,


### PR DESCRIPTION
Since `JUPYTERHUB_SERVICE_PREFIX` includes a trailing slash, `LOCALTILESERVER_CLIENT_PREFIX ` included a double slash in the URL, causing localtileserver requests for JupyterHub to break.

In addition, the current code made it impossible to override `LOCALTILESERVER_CLIENT_PREFIX` if any of the other conditions matched.  Now, it will only override if it's unset.