### PR TITLE
Bump version: 0.62.0 → 0.63.0

### DIFF
--- a/leafmap/__init__.py
+++ b/leafmap/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.62.0"
+__version__ = "0.63.0"
 
 import os
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "leafmap"
-version = "0.62.0"
+version = "0.63.0"
 dynamic = [
     "dependencies",
 ]
@@ -63,7 +63,7 @@ dependencies = {file = ["requirements.txt"]}
 universal = true
 
 [tool.bumpversion]
-current_version = "0.62.0"
+current_version = "0.63.0"
 commit = true
 tag = true
 


### PR DESCRIPTION
Minor release bump 0.62.0 → 0.63.0.

Notable changes since 0.62.0:
- Fix maplibregl `add_raster` not rendering in containerized/webview Jupyter by routing local tile URLs through the jupyter-loopback bridge (#1337, fixes #1331).
- Fix toolbar flickering on hover in webview frontends such as VS Code by debouncing the hover events (#1338, fixes #1330).

Merging this and creating the GitHub Release `v0.63.0` will publish to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to **0.63.0** across project metadata and release settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->