### PR TITLE
Add Urban Heat Island mapping notebook with MODIS LST

### DIFF
--- a/docs/notebooks/117_urban_heat_island.ipynb
+++ b/docs/notebooks/117_urban_heat_island.ipynb
@@ -1,0 +1,370 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Urban Heat Island Mapping with MODIS Land Surface Temperature\n",
+    "\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/leafmap/blob/master/docs/notebooks/117_urban_heat_island.ipynb)\n",
+    "\n",
+    "This notebook demonstrates how to visualize and analyze **Urban Heat Island (UHI)** effects using MODIS MOD11A2 Land Surface Temperature (LST) data and [leafmap](https://leafmap.org).\n",
+    "\n",
+    "The Urban Heat Island effect describes how urban areas exhibit significantly higher temperatures than surrounding rural land due to human activity, impervious surfaces, and reduced vegetation. LST derived from thermal infrared satellite sensors is one of the most widely used proxies for quantifying UHI intensity.\n",
+    "\n",
+    "**Outline:**\n",
+    "- Install and import dependencies\n",
+    "- Download MODIS MOD11A2 LST data via `earthaccess`\n",
+    "- Load and preprocess the LST GeoTIFF\n",
+    "- Apply scale factor and mask fill values\n",
+    "- Visualize LST on an interactive leafmap\n",
+    "- Compute a split map comparing urban vs. rural thermal patterns\n",
+    "- Export results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install dependencies\n",
+    "\n",
+    "Uncomment if running in Google Colab or a fresh environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install leafmap earthaccess rioxarray matplotlib numpy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import rioxarray as rxr\n",
+    "import earthaccess\n",
+    "import leafmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authenticate with NASA Earthdata\n",
+    "\n",
+    "A free NASA Earthdata account is required. Register at [urs.earthdata.nasa.gov](https://urs.earthdata.nasa.gov). Credentials are stored in `~/.netrc` after first login."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "earthaccess.login(persist=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Search for MODIS MOD11A2 LST data\n",
+    "\n",
+    "MOD11A2 provides 8-day composite Land Surface Temperature at 1 km resolution. We search for a summer granule over Lahore, Pakistan — one of South Asia's most prominent Urban Heat Island cities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lahore, Pakistan bounding box [west, south, east, north]\n",
+    "bbox = (73.8, 31.3, 74.6, 31.7)\n",
+    "\n",
+    "results = earthaccess.search_data(\n",
+    "    short_name=\"MOD11A2\",\n",
+    "    version=\"061\",\n",
+    "    bounding_box=bbox,\n",
+    "    temporal=(\"2023-06-01\", \"2023-06-30\"),\n",
+    ")\n",
+    "\n",
+    "print(f\"Found {len(results)} granule(s)\")\n",
+    "results[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download the LST granule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files = earthaccess.download(results[:1], local_path=\"modis_lst\")\n",
+    "hdf_path = files[0]\n",
+    "print(f\"Downloaded: {hdf_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and preprocess LST\n",
+    "\n",
+    "MOD11A2 stores LST as scaled integers. The LST Day layer (`LST_Day_1km`) must be multiplied by **0.02** to convert to Kelvin, then subtract 273.15 for Celsius. Fill value **0** is masked out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the daytime LST subdataset\n",
+    "lst_raw = rxr.open_rasterio(\n",
+    "    f'HDF4_EOS:EOS_GRID:\"{hdf_path}\":MODIS_Grid_8Day_1km_LST:LST_Day_1km',\n",
+    "    masked=True,\n",
+    ").squeeze()\n",
+    "\n",
+    "# Apply scale factor and convert to Celsius\n",
+    "lst_kelvin = lst_raw.where(lst_raw != 0) * 0.02\n",
+    "lst_celsius = lst_kelvin - 273.15\n",
+    "\n",
+    "print(f\"LST range: {float(lst_celsius.min()):.1f} °C  to  {float(lst_celsius.max()):.1f} °C\")\n",
+    "lst_celsius"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Quick static plot\n",
+    "\n",
+    "A preliminary view before loading into leafmap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 7))\n",
+    "lst_celsius.plot(\n",
+    "    ax=ax,\n",
+    "    cmap=\"RdYlBu_r\",\n",
+    "    robust=True,\n",
+    "    cbar_kwargs={\"label\": \"Land Surface Temperature (°C)\"},\n",
+    ")\n",
+    "ax.set_title(\"MODIS MOD11A2 — Daytime LST, Lahore, June 2023\", fontsize=13)\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"lahore_lst.png\", dpi=150)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export preprocessed LST as GeoTIFF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lst_output = \"lahore_lst_celsius.tif\"\n",
+    "lst_celsius.rio.to_raster(lst_output)\n",
+    "print(f\"Saved: {lst_output}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize on an interactive leafmap\n",
+    "\n",
+    "Load the LST raster with a diverging colormap. Warmer colours (red/orange) indicate urban heat pockets; cooler blues indicate vegetated or rural land."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
+    "m.add_basemap(\"OpenStreetMap\")\n",
+    "\n",
+    "m.add_raster(\n",
+    "    lst_output,\n",
+    "    colormap=\"RdYlBu_r\",\n",
+    "    layer_name=\"LST Day (°C)\",\n",
+    "    opacity=0.75,\n",
+    ")\n",
+    "\n",
+    "m.add_colorbar(\n",
+    "    cmap=\"RdYlBu_r\",\n",
+    "    label=\"Land Surface Temperature (°C)\",\n",
+    "    position=\"bottomright\",\n",
+    ")\n",
+    "\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Split map — LST vs. Satellite basemap\n",
+    "\n",
+    "The split map widget lets you swipe between the LST layer and the satellite basemap, making it easy to correlate high-temperature zones with built-up surfaces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2 = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
+    "\n",
+    "left_layer = leafmap.basemap_to_tiles(leafmap.basemaps.SATELLITE)\n",
+    "right_layer = leafmap.basemap_to_tiles(leafmap.basemaps.OpenStreetMap)\n",
+    "\n",
+    "m2.split_map(\n",
+    "    left_layer=left_layer,\n",
+    "    right_layer=right_layer,\n",
+    ")\n",
+    "\n",
+    "m2.add_raster(\n",
+    "    lst_output,\n",
+    "    colormap=\"RdYlBu_r\",\n",
+    "    layer_name=\"LST Day (°C)\",\n",
+    "    opacity=0.7,\n",
+    ")\n",
+    "\n",
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute UHI intensity\n",
+    "\n",
+    "A simple UHI index: difference between each pixel and the scene mean LST. Positive values = warmer than average (urban heat zones)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scene_mean = float(lst_celsius.mean())\n",
+    "uhi_index = lst_celsius - scene_mean\n",
+    "\n",
+    "uhi_output = \"lahore_uhi_index.tif\"\n",
+    "uhi_index.rio.to_raster(uhi_output)\n",
+    "\n",
+    "print(f\"Scene mean LST: {scene_mean:.2f} °C\")\n",
+    "print(f\"Max UHI intensity: +{float(uhi_index.max()):.2f} °C\")\n",
+    "print(f\"Min UHI intensity: {float(uhi_index.min()):.2f} °C\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize UHI index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m3 = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
+    "m3.add_basemap(\"SATELLITE\")\n",
+    "\n",
+    "m3.add_raster(\n",
+    "    uhi_output,\n",
+    "    colormap=\"seismic\",\n",
+    "    layer_name=\"UHI Index (°C above mean)\",\n",
+    "    opacity=0.75,\n",
+    ")\n",
+    "\n",
+    "m3.add_colorbar(\n",
+    "    cmap=\"seismic\",\n",
+    "    label=\"UHI Index (°C above scene mean)\",\n",
+    "    position=\"bottomright\",\n",
+    ")\n",
+    "\n",
+    "m3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated how to:\n",
+    "\n",
+    "1. Search and download MODIS MOD11A2 LST data using `earthaccess`\n",
+    "2. Apply scale factors and unit conversions with `rioxarray`\n",
+    "3. Visualize LST interactively with `leafmap` and a diverging colormap\n",
+    "4. Build a split map to compare LST against basemap layers\n",
+    "5. Compute a simple Urban Heat Island intensity index\n",
+    "\n",
+    "The workflow is applicable to any city worldwide — change `bbox` and `temporal` to explore different regions and seasons.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "- [MODIS MOD11A2 Product Page](https://lpdaac.usgs.gov/products/mod11a2v061/) — LP DAAC\n",
+    "- [earthaccess](https://earthaccess.readthedocs.io/) — NASA Earthdata Python library\n",
+    "- [leafmap](https://leafmap.org/) — Wu, 2021\n",
+    "- [rioxarray](https://corteva.github.io/rioxarray/)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/notebooks/117_urban_heat_island.ipynb
+++ b/docs/notebooks/117_urban_heat_island.ipynb
@@ -150,7 +150,9 @@
     "lst_kelvin = lst_raw.where(lst_raw != 0) * 0.02\n",
     "lst_celsius = lst_kelvin - 273.15\n",
     "\n",
-    "print(f\"LST range: {float(lst_celsius.min()):.1f} °C  to  {float(lst_celsius.max()):.1f} °C\")\n",
+    "print(\n",
+    "    f\"LST range: {float(lst_celsius.min()):.1f} °C  to  {float(lst_celsius.max()):.1f} °C\"\n",
+    ")\n",
     "lst_celsius"
    ]
   },

--- a/docs/notebooks/117_urban_heat_island.ipynb
+++ b/docs/notebooks/117_urban_heat_island.ipynb
@@ -92,20 +92,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Lahore, Pakistan bounding box [west, south, east, north]\n",
-    "bbox = (73.8, 31.3, 74.6, 31.7)\n",
-    "\n",
-    "results = earthaccess.search_data(\n",
-    "    short_name=\"MOD11A2\",\n",
-    "    version=\"061\",\n",
-    "    bounding_box=bbox,\n",
-    "    temporal=(\"2023-06-01\", \"2023-06-30\"),\n",
-    ")\n",
-    "\n",
-    "print(f\"Found {len(results)} granule(s)\")\n",
-    "results[0]"
-   ]
+   "source": "# Lahore, Pakistan bounding box [west, south, east, north]\nbbox = (73.8, 31.3, 74.6, 31.7)\n\nresults = earthaccess.search_data(\n    short_name=\"MOD11A2\",\n    version=\"061\",\n    bounding_box=bbox,\n    temporal=(\"2023-06-01\", \"2023-06-30\"),\n)\n\nprint(f\"Found {len(results)} granule(s)\")\nif not results:\n    raise ValueError(\n        \"No granules found — check your Earthdata credentials and the search parameters.\"\n    )\nresults[0]"
   },
   {
    "cell_type": "markdown",
@@ -119,11 +106,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "files = earthaccess.download(results[:1], local_path=\"modis_lst\")\n",
-    "hdf_path = files[0]\n",
-    "print(f\"Downloaded: {hdf_path}\")"
-   ]
+   "source": "files = earthaccess.download(results[:1], local_path=\"modis_lst\")\nif not files:\n    raise ValueError(\"Download failed — no files returned by earthaccess.\")\nhdf_path = files[0]\nprint(f\"Downloaded: {hdf_path}\")"
   },
   {
    "cell_type": "markdown",
@@ -218,60 +201,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "m = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
-    "m.add_basemap(\"OpenStreetMap\")\n",
-    "\n",
-    "m.add_raster(\n",
-    "    lst_output,\n",
-    "    colormap=\"RdYlBu_r\",\n",
-    "    layer_name=\"LST Day (°C)\",\n",
-    "    opacity=0.75,\n",
-    ")\n",
-    "\n",
-    "m.add_colorbar(\n",
-    "    cmap=\"RdYlBu_r\",\n",
-    "    label=\"Land Surface Temperature (°C)\",\n",
-    "    position=\"bottomright\",\n",
-    ")\n",
-    "\n",
-    "m"
-   ]
+   "source": "m = leafmap.Map(center=[31.5, 74.2], zoom=10)\nm.add_basemap(\"OpenStreetMap\")\n\nm.add_raster(\n    lst_output,\n    colormap=\"RdYlBu_r\",\n    layer_name=\"LST Day (°C)\",\n    opacity=0.75,\n)\n\n# RdYlBu_r: blue (cool) → yellow → red (hot)\nlst_colors = [\"313695\", \"74ADD1\", \"E0F3F8\", \"FEE090\", \"F46D43\", \"D73027\"]\nm.add_colorbar(colors=lst_colors, vmin=20, vmax=50)\n\nm"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Split map — LST vs. Satellite basemap\n",
-    "\n",
-    "The split map widget lets you swipe between the LST layer and the satellite basemap, making it easy to correlate high-temperature zones with built-up surfaces."
-   ]
+   "source": "## Split map — satellite vs. OpenStreetMap\n\nSwipe between the satellite basemap and OpenStreetMap to compare land cover with the LST overlay, making it easy to correlate high-temperature zones with built-up surfaces."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "m2 = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
-    "\n",
-    "left_layer = leafmap.basemap_to_tiles(leafmap.basemaps.SATELLITE)\n",
-    "right_layer = leafmap.basemap_to_tiles(leafmap.basemaps.OpenStreetMap)\n",
-    "\n",
-    "m2.split_map(\n",
-    "    left_layer=left_layer,\n",
-    "    right_layer=right_layer,\n",
-    ")\n",
-    "\n",
-    "m2.add_raster(\n",
-    "    lst_output,\n",
-    "    colormap=\"RdYlBu_r\",\n",
-    "    layer_name=\"LST Day (°C)\",\n",
-    "    opacity=0.7,\n",
-    ")\n",
-    "\n",
-    "m2"
-   ]
+   "source": "m2 = leafmap.Map(center=[31.5, 74.2], zoom=10)\nm2.split_map(\n    left_layer=\"SATELLITE\",\n    right_layer=\"OpenStreetMap\",\n    left_label=\"Satellite\",\n    right_label=\"OpenStreetMap\",\n)\nm2.add_raster(\n    lst_output,\n    colormap=\"RdYlBu_r\",\n    layer_name=\"LST Day (°C)\",\n    opacity=0.7,\n)\nm2"
   },
   {
    "cell_type": "markdown",
@@ -311,25 +253,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "m3 = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
-    "m3.add_basemap(\"SATELLITE\")\n",
-    "\n",
-    "m3.add_raster(\n",
-    "    uhi_output,\n",
-    "    colormap=\"seismic\",\n",
-    "    layer_name=\"UHI Index (°C above mean)\",\n",
-    "    opacity=0.75,\n",
-    ")\n",
-    "\n",
-    "m3.add_colorbar(\n",
-    "    cmap=\"seismic\",\n",
-    "    label=\"UHI Index (°C above scene mean)\",\n",
-    "    position=\"bottomright\",\n",
-    ")\n",
-    "\n",
-    "m3"
-   ]
+   "source": "m3 = leafmap.Map(center=[31.5, 74.2], zoom=10)\nm3.add_basemap(\"SATELLITE\")\n\nm3.add_raster(\n    uhi_output,\n    colormap=\"seismic\",\n    layer_name=\"UHI Index (°C above mean)\",\n    opacity=0.75,\n)\n\n# seismic: blue (below mean) → white → red (above mean / urban heat)\nuhi_colors = [\"3333CC\", \"AAAAFF\", \"FFFFFF\", \"FFAAAA\", \"CC3333\"]\nm3.add_colorbar(colors=uhi_colors, vmin=-5, vmax=5)\n\nm3"
   },
   {
    "cell_type": "markdown",

--- a/docs/notebooks/117_urban_heat_island.ipynb
+++ b/docs/notebooks/117_urban_heat_island.ipynb
@@ -16,7 +16,7 @@
     "- Install and import dependencies\n",
     "- Download MODIS MOD11A2 LST data via `earthaccess`\n",
     "- Load and preprocess the LST GeoTIFF\n",
-    "- Apply scale factor and mask fill values\n",
+    "- Clip to the study area, apply the scale factor, and mask fill/low-quality pixels\n",
     "- Visualize LST on an interactive leafmap\n",
     "- Compute a split map comparing urban vs. rural thermal patterns\n",
     "- Export results"
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install leafmap earthaccess rioxarray matplotlib numpy"
+    "# %pip install leafmap earthaccess rioxarray matplotlib"
    ]
   },
   {
@@ -53,7 +53,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import rioxarray as rxr\n",
     "import earthaccess\n",
@@ -106,7 +105,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "files = earthaccess.download(results[:1], local_path=\"modis_lst\")\nif not files:\n    raise ValueError(\"Download failed — no files returned by earthaccess.\")\nhdf_path = files[0]\nprint(f\"Downloaded: {hdf_path}\")"
+   "source": [
+    "files = earthaccess.download(results[:1], local_path=\"modis_lst\")\n",
+    "# earthaccess may return sidecar files (e.g. .hdf.xml) alongside the data file,\n",
+    "# and the ordering is not guaranteed, so select the HDF explicitly.\n",
+    "hdf_path = next((f for f in files if str(f).endswith(\".hdf\")), None)\n",
+    "if hdf_path is None:\n",
+    "    raise ValueError(\"Download failed — no HDF file returned by earthaccess.\")\n",
+    "print(f\"Downloaded: {hdf_path}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -114,7 +121,9 @@
    "source": [
     "## Load and preprocess LST\n",
     "\n",
-    "MOD11A2 stores LST as scaled integers. The LST Day layer (`LST_Day_1km`) must be multiplied by **0.02** to convert to Kelvin, then subtract 273.15 for Celsius. Fill value **0** is masked out."
+    "A MOD11A2 granule covers an entire MODIS tile (~1200 km across), so we first clip it to the Lahore bounding box — otherwise the scene statistics below would describe the whole tile rather than the city.\n",
+    "\n",
+    "MOD11A2 stores LST as scaled integers. The LST Day layer (`LST_Day_1km`) must be multiplied by **0.02** to convert to Kelvin, then subtract 273.15 for Celsius. Fill value **0** is masked out, and the `QC_Day` layer is used to drop cloud-contaminated and other low-quality retrievals."
    ]
   },
   {
@@ -123,14 +132,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Open the daytime LST subdataset\n",
-    "lst_raw = rxr.open_rasterio(\n",
-    "    f'HDF4_EOS:EOS_GRID:\"{hdf_path}\":MODIS_Grid_8Day_1km_LST:LST_Day_1km',\n",
-    "    masked=True,\n",
-    ").squeeze()\n",
+    "grid = f'HDF4_EOS:EOS_GRID:\"{hdf_path}\":MODIS_Grid_8Day_1km_LST:'\n",
+    "\n",
+    "# Open the daytime LST subdataset and its quality layer\n",
+    "lst_raw = rxr.open_rasterio(grid + \"LST_Day_1km\", masked=True).squeeze()\n",
+    "qc_day = rxr.open_rasterio(grid + \"QC_Day\").squeeze()\n",
+    "\n",
+    "# Clip the granule to the Lahore bounding box before computing any statistics\n",
+    "lst_raw = lst_raw.rio.clip_box(*bbox, crs=\"EPSG:4326\")\n",
+    "qc_day = qc_day.rio.clip_box(*bbox, crs=\"EPSG:4326\")\n",
+    "\n",
+    "# QC_Day bits 0-1 are the mandatory QA flags; 00 means good-quality LST was\n",
+    "# produced. Anything else is cloud-contaminated or otherwise unreliable.\n",
+    "good_quality = (qc_day & 0b11) == 0\n",
     "\n",
     "# Apply scale factor and convert to Celsius\n",
-    "lst_kelvin = lst_raw.where(lst_raw != 0) * 0.02\n",
+    "lst_kelvin = lst_raw.where((lst_raw != 0) & good_quality) * 0.02\n",
     "lst_celsius = lst_kelvin - 273.15\n",
     "\n",
     "print(\n",
@@ -201,19 +218,51 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "m = leafmap.Map(center=[31.5, 74.2], zoom=10)\nm.add_basemap(\"OpenStreetMap\")\n\nm.add_raster(\n    lst_output,\n    colormap=\"RdYlBu_r\",\n    layer_name=\"LST Day (°C)\",\n    opacity=0.75,\n)\n\n# RdYlBu_r: blue (cool) → yellow → red (hot)\nlst_colors = [\"313695\", \"74ADD1\", \"E0F3F8\", \"FEE090\", \"F46D43\", \"D73027\"]\nm.add_colorbar(colors=lst_colors, vmin=20, vmax=50)\n\nm"
+   "source": [
+    "m = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
+    "m.add_basemap(\"OpenStreetMap\")\n",
+    "\n",
+    "m.add_raster(\n",
+    "    lst_output,\n",
+    "    colormap=\"RdYlBu_r\",\n",
+    "    vmin=20,\n",
+    "    vmax=50,\n",
+    "    layer_name=\"LST Day (°C)\",\n",
+    "    opacity=0.75,\n",
+    ")\n",
+    "\n",
+    "# RdYlBu_r: blue (cool) → yellow → red (hot)\n",
+    "lst_colors = [\"313695\", \"74ADD1\", \"E0F3F8\", \"FEE090\", \"F46D43\", \"D73027\"]\n",
+    "m.add_colorbar(colors=lst_colors, vmin=20, vmax=50)\n",
+    "\n",
+    "m"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Split map — satellite vs. OpenStreetMap\n\nSwipe between the satellite basemap and OpenStreetMap to compare land cover with the LST overlay, making it easy to correlate high-temperature zones with built-up surfaces."
+   "source": [
+    "## Split map — LST vs. satellite\n",
+    "\n",
+    "Swipe between the LST raster and the satellite basemap to correlate high-temperature zones with built-up surfaces."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "m2 = leafmap.Map(center=[31.5, 74.2], zoom=10)\nm2.split_map(\n    left_layer=\"SATELLITE\",\n    right_layer=\"OpenStreetMap\",\n    left_label=\"Satellite\",\n    right_label=\"OpenStreetMap\",\n)\nm2.add_raster(\n    lst_output,\n    colormap=\"RdYlBu_r\",\n    layer_name=\"LST Day (°C)\",\n    opacity=0.7,\n)\nm2"
+   "source": [
+    "m2 = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
+    "m2.split_map(\n",
+    "    left_layer=lst_output,\n",
+    "    right_layer=\"SATELLITE\",\n",
+    "    left_args={\"colormap\": \"RdYlBu_r\", \"vmin\": 20, \"vmax\": 50, \"opacity\": 0.9},\n",
+    "    left_label=\"LST Day (°C)\",\n",
+    "    right_label=\"Satellite\",\n",
+    ")\n",
+    "m2"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -221,7 +270,7 @@
    "source": [
     "## Compute UHI intensity\n",
     "\n",
-    "A simple UHI index: difference between each pixel and the scene mean LST. Positive values = warmer than average (urban heat zones)."
+    "A simple UHI index: difference between each pixel and the mean LST of the study area. Positive values = warmer than average (urban heat zones)."
    ]
   },
   {
@@ -253,7 +302,25 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "m3 = leafmap.Map(center=[31.5, 74.2], zoom=10)\nm3.add_basemap(\"SATELLITE\")\n\nm3.add_raster(\n    uhi_output,\n    colormap=\"seismic\",\n    layer_name=\"UHI Index (°C above mean)\",\n    opacity=0.75,\n)\n\n# seismic: blue (below mean) → white → red (above mean / urban heat)\nuhi_colors = [\"3333CC\", \"AAAAFF\", \"FFFFFF\", \"FFAAAA\", \"CC3333\"]\nm3.add_colorbar(colors=uhi_colors, vmin=-5, vmax=5)\n\nm3"
+   "source": [
+    "m3 = leafmap.Map(center=[31.5, 74.2], zoom=10)\n",
+    "m3.add_basemap(\"SATELLITE\")\n",
+    "\n",
+    "m3.add_raster(\n",
+    "    uhi_output,\n",
+    "    colormap=\"seismic\",\n",
+    "    vmin=-5,\n",
+    "    vmax=5,\n",
+    "    layer_name=\"UHI Index (°C above mean)\",\n",
+    "    opacity=0.75,\n",
+    ")\n",
+    "\n",
+    "# seismic: blue (below mean) → white → red (above mean / urban heat)\n",
+    "uhi_colors = [\"3333CC\", \"AAAAFF\", \"FFFFFF\", \"FFAAAA\", \"CC3333\"]\n",
+    "m3.add_colorbar(colors=uhi_colors, vmin=-5, vmax=5)\n",
+    "\n",
+    "m3"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/zensical.toml
+++ b/zensical.toml
@@ -291,6 +291,7 @@ nav = [
     { "114_nasa_fire" = "notebooks/114_nasa_fire.md" },
     { "115_terrascope" = "notebooks/115_terrascope.md" },
     { "116_hls_nasa_earthdata" = "notebooks/116_hls_nasa_earthdata.md" },
+    { "117_urban_heat_island" = "notebooks/117_urban_heat_island.md" },
   ] },
 ]
 


### PR DESCRIPTION
## Description

Adds `docs/notebooks/117_urban_heat_island.ipynb` — an end-to-end notebook for visualizing Urban Heat Island (UHI) effects using MODIS MOD11A2 Land Surface Temperature data and leafmap.

## What this notebook covers

- Searching and downloading MODIS MOD11A2 (8-day LST, 1 km) via `earthaccess`
- Applying scale factor (×0.02) and Kelvin→Celsius conversion with `rioxarray`
- Rendering LST on an interactive leafmap with a diverging colormap and colorbar
- Building a split map to compare LST against satellite and street basemaps
- Computing a simple Urban Heat Island intensity index (pixel LST − scene mean)

## Study area

Lahore, Pakistan — a South Asian megacity with well-documented UHI intensity, using a June 2023 summer granule to capture peak thermal contrast between built-up and vegetated land.

## Motivation

No UHI or thermal LST example currently exists in the docs (notebooks 00–116). This fills that gap with a workflow directly applicable to climate research, urban planning, and heat risk assessment.

## Related notebooks

- `116_hls_nasa_earthdata.ipynb` — NASA Earthdata access (same `earthaccess` pattern)
- `05_load_raster.ipynb` — raster loading
- `12_split_map.ipynb` — split map widget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a complete Jupyter notebook demonstrating Urban Heat Island analysis for Lahore, Pakistan.
  * Shows how to retrieve and process MODIS land surface temperature data, apply quality filtering, and convert temperatures to Celsius.
  * Includes static and interactive visualizations, satellite comparisons, and split-map views.
  * Computes, exports, and visualizes land surface temperature and Urban Heat Island results.
  * Added the notebook to the documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->