### PR TITLE
Fix KeyError in The_national_map_USGS.prodFormats 

### DIFF
--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -6296,17 +6296,19 @@ class The_national_map_USGS:
             return []
 
     @property
-    def prodFormats(self) -> list:
+    def prodFormats(self) -> set:
         """
         Return all datatypes available in any of the collections.
         Note that "All" is only peculiar to one dataset.
         """
-        return set(i["displayName"] for ds in self.DS for i in ds["formats"])
+        return set(
+            i["displayName"] for ds in self.DS if "formats" in ds for i in ds["formats"]
+        )
 
     @property
-    def datasets(self) -> list:
+    def datasets(self) -> set:
         """
-        Returns a list of dataset tags (most common human readable self description for specific datasets).
+        Returns a set of dataset tags (most common human readable self description for specific datasets).
         """
         return set(y["sbDatasetTag"] for x in self.DS for y in x["tags"])
 

--- a/leafmap/common.py
+++ b/leafmap/common.py
@@ -6301,9 +6301,7 @@ class The_national_map_USGS:
         Return all datatypes available in any of the collections.
         Note that "All" is only peculiar to one dataset.
         """
-        return set(
-            i["displayName"] for ds in self.DS if "formats" in ds for i in ds["formats"]
-        )
+        return {i["displayName"] for ds in self.DS for i in ds.get("formats", [])}
 
     @property
     def datasets(self) -> set:

--- a/leafmap/leafmap.py
+++ b/leafmap/leafmap.py
@@ -5585,7 +5585,7 @@ class Map(ipyleaflet.Map):
         return None
 
     def remove(self, widget: Any) -> None:
-        """Removes a widget to the map."""
+        """Removes a widget from the map."""
 
         basic_controls: Dict[str, ipyleaflet.Control] = {
             "layer_editor": map_widgets.LayerEditor,


### PR DESCRIPTION
Fixes #1352 

The Request response object of the dataset _Imagery - NAIP (1 meter to .5 foot)_ does not include a "formats" key, causing a KeyError when the set comprehension assumed it always existed.

- The set comprehension in `prodFormats` now checks if a "formats" key exists before accessing it.
- Changed the return type annotation of the `prodFormats` and `datasets` properties from list to set to match their actual (unchanged) runtime return type
- Updated the docstring of the `datasets` property to match the actual return type
- Fixed docstring typo in `Map.remove` method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset handling so entries without format information are skipped safely.
  * Corrected the reported return types for dataset and format listings.

* **Documentation**
  * Fixed wording in a map-removal description for clearer, more accurate text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->